### PR TITLE
Fix navigation regression test wiring to current page-actions module

### DIFF
--- a/src/main/ai/page-actions.ts
+++ b/src/main/ai/page-actions.ts
@@ -1028,6 +1028,22 @@ async function submitForm(
   return formInfo.submitted ? "Submitted form via POST" : "Submitted form";
 }
 
+export { waitForLoad, setElementValue };
+
+export async function clickElementBySelector(
+  wc: WebContents,
+  selector: string,
+): Promise<string> {
+  return clickElement(wc, selector);
+}
+
+export async function submitFormBySelector(
+  wc: WebContents,
+  selector: string,
+): Promise<string> {
+  return submitForm(wc, { selector });
+}
+
 async function pressKey(
   wc: WebContents,
   args: Record<string, any>,

--- a/tests/navigation-regression.ts
+++ b/tests/navigation-regression.ts
@@ -9,7 +9,7 @@ import {
   setElementValue,
   submitFormBySelector,
   waitForLoad,
-} from "../src/main/browser/page-interactions";
+} from "../src/main/ai/page-actions";
 import { Tab } from "../src/main/tabs/tab";
 import { createNavigationHarnessServer } from "./fixtures/navigation-harness";
 


### PR DESCRIPTION
### Motivation
- The navigation regression tests referenced a removed helper module path and needed to use the current page interaction implementation so tests can exercise the real interaction helpers.

### Description
- Updated `tests/navigation-regression.ts` to import helpers from `src/main/ai/page-actions` instead of the removed `src/main/browser/page-interactions`.
- Exported existing `waitForLoad` and `setElementValue` from `src/main/ai/page-actions.ts` and added thin compatibility wrappers `clickElementBySelector` and `submitFormBySelector` that delegate to the internal implementations.
- The changes preserve internal function behavior and provide a stable API surface for tests and external callers.

### Testing
- Ran `npm run typecheck` and it completed successfully.
- Ran `npm run build` and it completed successfully.
- Ran `npx tsx --test tests/dom-selectors.test.ts` and the suite passed (2/2 tests).
- Ran `npx tsx tests/navigation-regression.ts` under plain Node and it failed because Electron APIs like `app.whenReady()` are not available in that execution mode.
- Attempted to run the regression suite with Electron (`npx electron -r tsx/cjs tests/navigation-regression.ts`) and it could not run in this container due to a missing native dependency (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b124efc9f883238347458328c68db1)