### PR TITLE
Add smoke-test runner and fix navigation-regression script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist:dir": "npm run build && electron-builder --linux dir",
     "preview": "electron-vite preview",
     "typecheck": "tsc --noEmit",
-    "test:navigation-regression": "electron scripts/run-navigation-regression.mjs",
+    "test:navigation-regression": "electron --import tsx tests/navigation-regression.ts",
     "smoke:test": "node scripts/smoke-test.mjs"
   },
   "keywords": [

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,52 @@
+import { spawn } from 'node:child_process';
+import process from 'node:process';
+
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const steps = [
+  { name: 'Typecheck', args: ['run', 'typecheck'] },
+  { name: 'Build', args: ['run', 'build'] },
+  { name: 'Navigation regression', args: ['run', 'test:navigation-regression'] },
+];
+
+function runStep(step) {
+  return new Promise((resolve, reject) => {
+    process.stdout.write(`\n[smoke] ${step.name}: npm ${step.args.join(' ')}\n`);
+
+    const child = spawn(npmCommand, step.args, {
+      stdio: 'inherit',
+      env: process.env,
+    });
+
+    child.on('error', (error) => {
+      reject(new Error(`[smoke] Failed to start ${step.name}: ${error.message}`));
+    });
+
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      if (signal) {
+        reject(new Error(`[smoke] ${step.name} terminated by signal ${signal}`));
+        return;
+      }
+
+      reject(new Error(`[smoke] ${step.name} failed with exit code ${code ?? 'unknown'}`));
+    });
+  });
+}
+
+async function main() {
+  for (const step of steps) {
+    await runStep(step);
+  }
+
+  process.stdout.write('\n[smoke] All smoke-test steps passed.\n');
+}
+
+main().catch((error) => {
+  process.stderr.write(`\n${error.message}\n`);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
### Motivation
- The release smoke path failed because `npm run smoke:test` referenced a missing script and the navigation regression target pointed at a non-existent file, causing CI to error immediately.

### Description
- Add `scripts/smoke-test.mjs` to orchestrate the release smoke pipeline and run steps sequentially with logging and fail-fast behavior.
- Update `package.json` `test:navigation-regression` to `electron --import tsx tests/navigation-regression.ts` so the existing TypeScript regression suite is executed directly via Electron and the `tsx` loader.
- The runner selects the correct npm binary on Windows and streams subprocess output to the parent process for clear diagnostics.

### Testing
- Ran `npm run smoke:test` which executed the new runner end-to-end up to Electron startup and returned step-level results.
- `Typecheck` (`npm run typecheck`) completed successfully.
- `Build` (`npm run build`) completed successfully.
- `Navigation regression` (`npm run test:navigation-regression`) invoked Electron but failed to start in this container due to a missing system library `libatk-1.0.so.0`, so the wiring is validated but the regression cannot run here (exit code 127).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b2a11ee083238d9a6fc4f97272f2)