### PR TITLE
Disable Electron setuid sandbox for navigation regression test

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dist:dir": "npm run build && electron-builder --linux dir",
     "preview": "electron-vite preview",
     "typecheck": "tsc --noEmit",
-    "test:navigation-regression": "electron --import tsx tests/navigation-regression.ts",
+    "test:navigation-regression": "electron --no-sandbox --disable-setuid-sandbox --import tsx tests/navigation-regression.ts",
     "smoke:test": "node scripts/smoke-test.mjs"
   },
   "keywords": [


### PR DESCRIPTION
### Motivation
- Fix CI failure where Electron aborts due to an unconfigured SUID `chrome-sandbox` helper in non-privileged/containerized runners by avoiding reliance on the setuid sandbox.

### Description
- Update the `test:navigation-regression` npm script in `package.json` to launch Electron with `--no-sandbox --disable-setuid-sandbox --import tsx tests/navigation-regression.ts`.

### Testing
- Ran `npm run typecheck` and `npm run build` successfully, and attempted `npm run test:navigation-regression` which could not start Electron in this environment due to a missing system library `libatk-1.0.so.0` (so the regression test could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4b7a525c88323917ad2f134bfbb82)