### PR TITLE
Fix dev→main promotion workflow failing without a checkout (scope GH CLI PR commands)

### DIFF
--- a/.github/workflows/promote-dev-to-main.yml
+++ b/.github/workflows/promote-dev-to-main.yml
@@ -12,6 +12,8 @@ concurrency:
 jobs:
   promote:
     runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
     permissions:
       contents: write
       pull-requests: write
@@ -41,16 +43,17 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          pr_number=$(gh pr list --state open --base main --head dev --json number --jq '.[0].number // empty')
+          pr_number=$(gh pr list --repo "$GH_REPO" --state open --base main --head dev --json number --jq '.[0].number // empty')
 
           if [ -z "$pr_number" ]; then
             gh pr create \
+              --repo "$GH_REPO" \
               --base main \
               --head dev \
               --title "Promote dev to main" \
               --body "Automated daily promotion PR from \`dev\` to \`main\`.\n\nThis PR is created by \`.github/workflows/promote-dev-to-main.yml\` and is intended to auto-merge once required checks pass."
 
-            pr_number=$(gh pr list --state open --base main --head dev --json number --jq '.[0].number // empty')
+            pr_number=$(gh pr list --repo "$GH_REPO" --state open --base main --head dev --json number --jq '.[0].number // empty')
           else
             echo "Using existing promotion PR #$pr_number"
           fi
@@ -63,7 +66,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.promotion_pr.outputs.pr_number }}
         run: |
-          gh pr checks "$PR_NUMBER" --watch --fail-fast
+          gh pr checks --repo "$GH_REPO" "$PR_NUMBER" --watch --fail-fast
 
       - name: Merge promotion PR
         if: steps.compare.outputs.ahead_by != '0'
@@ -71,6 +74,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.promotion_pr.outputs.pr_number }}
         run: |
-          pr_head_sha=$(gh pr view "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
+          pr_head_sha=$(gh pr view --repo "$GH_REPO" "$PR_NUMBER" --json headRefOid --jq '.headRefOid')
 
-          gh pr merge "$PR_NUMBER" --merge --match-head-commit "$pr_head_sha"
+          gh pr merge --repo "$GH_REPO" "$PR_NUMBER" --merge --match-head-commit "$pr_head_sha"


### PR DESCRIPTION
### Motivation
- The scheduled promotion workflow failed with `fatal: not a git repository` because `gh pr` commands were executed without a local checkout and without explicit repository context.
- Make the promotion job resilient to running without `actions/checkout` so the promotion PR can be created and merged using API context.

### Description
- Add a job-level `GH_REPO` environment variable set to `${{ github.repository }}`.
- Update all `gh pr` invocations (`list`, `create`, `checks`, `view`, `merge`) to include `--repo "$GH_REPO"` so the GitHub CLI uses API context instead of requiring a local `.git` directory.
- Preserve existing workflow logic: the job still checks whether `dev` is ahead, reuses or creates the promotion PR, waits for checks, and merges when ready.

### Testing
- Ran `rg -n "Create or reuse promotion PR|ahead_by|gh pr list --state open --base main --head dev" .github/workflows` to locate the related workflow and it succeeded.
- Executed a `python -c` inspection that validated all required `--repo` flags are present in `.github/workflows/promote-dev-to-main.yml` and it reported no missing flags.
- Confirmed the workflow file change via `git status --short` and `git diff`/`git show` to ensure only the intended workflow file was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b598514eb48323a901ba1439085a70)