### PR TITLE
Add automated npm publishing to @quanta-intellect/vessel-browser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           node-version: 22
           cache: npm
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: npm ci
@@ -76,6 +77,16 @@ jobs:
           path: |
             dist/*.AppImage
             dist/SHASUMS256.txt
+
+      - name: Sync package.json version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
 
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ scripts/demo-extraction.mjs
 .claude/skills/gitnexus/gitnexus-refactoring/SKILL.md
 AGENTS.md
 CLAUDE.md
+docs/releasing.md

--- a/README.md
+++ b/README.md
@@ -12,18 +12,6 @@ Vessel gives external agent harnesses a real browser with durable state, MCP con
 
 *Vessel is in active development and currently makes no security assurances. Use and deploy it with care.*
 
-## What Vessel Gives a Harness
-
-When you point an MCP-capable agent at Vessel, it gets more than generic browser automation:
-
-- **A persistent browser runtime** with cookies, localStorage, tab layout, named sessions, and checkpoints
-- **Human-focused tab awareness** so the agent can cheaply tell which tab the human is currently looking at
-- **Structured page context** with headings, interactives, overlays, forms, and article metadata instead of raw DOM soup
-- **Bidirectional highlights and annotations** that show up both in the visible browser and in model-facing page context
-- **A visible supervisory surface** for approvals, runtime state, bookmarks, checkpoints, and transcript monitoring
-
-In practice, Vessel is meant to be the shared browser surface between the harness and the human, not just a remote-controlled renderer.
-
 ## Quick Start
 
 ### Fastest Install Today
@@ -48,47 +36,338 @@ npm install
 npm run dev
 ```
 
-## Why Vessel?
+### Why Vessel?
 
 Most browser automation stacks are either headless, stateless, or designed around a human as the primary operator. Vessel is built around the opposite model: the browser is the agent's operating surface, and the human stays in the loop through a visible interface with clear supervisory controls.
 
 <img width="1280" height="800" alt="vessel_2026-03-16_144201_7545" src="https://github.com/user-attachments/assets/da7b28ea-6c5f-4aa7-909e-0a255c80d508" />
 
+
 <img width="1280" height="785" alt="vessel_2026-03-16_171108_8677" src="https://github.com/user-attachments/assets/613c285f-0253-4344-b335-f74a64e124ac" />
+
 
 Vessel is built for persistent web agents that need a real browser, durable state, and a human-visible interface. The agent is the primary operator. The human follows along in the live browser UI, audits what the agent is doing, and steers when needed.
 
+Today, Vessel provides the browser shell, page visibility, and supervisory surfaces needed to support that model. The long-term goal is not "a browser with AI features," but a browser runtime for autonomous agents with a clear supervisory experience for humans.
+
 ## Features
 
-- **Agent-first browser model** with a visible browser instead of a headless black box
-- **Active tab awareness** through `vessel_current_tab` and `vessel://tabs/active`
-- **Structured page reads** with headings, forms, overlays, structured data, and annotations
-- **Bidirectional highlighting** that is visible in-browser and reflected back into model-facing context
-- **Supervisor Sidebar** (`Ctrl+Shift+L`) for approvals, checkpoints, bookmarks, and transcript monitoring
-- **Named session persistence** for cookies, localStorage, and tab layout
-- **Popup recovery and ad-block controls** for fragile sites and stubborn flows
-- **Obsidian memory hooks** for notes, captures, and research breadcrumbs
-- **Reader mode, focus mode, and a minimal dark UI** built around the page, not the chrome
+- **Agent-first browser model** — Vessel is designed around an agent driving the browser while a human watches, intervenes, and redirects
+- **Human-visible browser UI** — pages render like a normal browser so agent activity stays legible instead of disappearing into a headless run
+- **Command Bar** (`Ctrl+L`) — a secondary operator surface for harness-driven workflows and future runtime commands
+- **Supervisor Sidebar** (`Ctrl+Shift+L`) — live supervision across four tabs: Supervisor, Bookmarks, Checkpoints, and Chat
+- **Chat Assistant** — built-in conversational AI in the sidebar Chat tab; supports Anthropic, OpenAI, Ollama, Mistral, xAI, Google Gemini, OpenRouter, and any OpenAI-compatible endpoint; reads the current page automatically; has full access to the same browser tools as external agents; multi-turn session history; configure provider, model, and API key in Settings
+- **Dev Tools Panel** (`F12`) — inspect console output, network requests, and MCP/agent activity in a resizable panel at the bottom of the window; export logs by category and date range as JSON
+- **Bookmarks for Agents** — save pages into folders, attach one-line folder summaries, and search bookmarks over MCP instead of dumping the entire library
+- **Named Session Persistence** — save cookies, localStorage, and current tab layout under a reusable name, then reload it after a restart
+- **Structured Page Visibility Context** — extraction can report in-viewport elements, obscured controls, active overlays, and dormant consent/modal UI
+- **Popup Recovery Tools** — agents can explicitly dismiss common popups, newsletter gates, and consent walls instead of brute-forcing generic clicks
+- **Per-Tab Ad Blocking Controls** — tabs default to ad blocking on, but agents can selectively disable and re-enable blocking when a page misbehaves
+- **Obsidian Memory Hooks** — optional vault path for agent-written markdown notes, page captures, and research breadcrumbs
+- **Runtime Health Checks** — startup warnings for MCP port conflicts, unreadable settings, and user-data write failures
+- **Reader Mode** — extract article content into a clean, distraction-free view; toggle on and off from the address bar
+- **Focus Mode** (`Ctrl+Shift+F`) — hide all chrome, content fills the screen
+- **Resizable Panels** — drag the sidebar edge to resize; width persists across sessions
+- **Minimal Dark Theme** — warm dark grays, restrained accent color, and no pure black/white
 
-## Docs
+## Positioning
 
-- [MCP Setup And Harness Integration](./docs/mcp.md)
-- [Development Guide](./docs/development.md)
-- [Architecture](./docs/architecture.md)
-- [Packaging And Releases](./docs/releasing.md)
-- [Agent Roadmap](./docs/agent-roadmap.md)
+Most browsers treat automation as secondary and assume a human is the primary actor. Vessel is the opposite: it is the browser for the agent, with a visible interface that keeps the human in the loop.
+
+That means the product should optimize for:
+
+- persistent browser state across tasks and sessions
+- clear visibility into what the agent is doing right now
+- lightweight human intervention instead of constant manual driving
+- a browser runtime that can serve long-lived agent systems such as Hermes Agent or OpenClaw-style harnesses
+
+## Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Engine | Chromium (Electron 40) |
+| UI Framework | SolidJS |
+| Language | TypeScript |
+| Build | electron-vite + Vite |
+| AI Control | External agent harnesses (Hermes Agent, OpenClaw, MCP clients) + built-in chat (Anthropic, OpenAI, Ollama, and any OAI-compatible endpoint) |
+| Content Extraction | @mozilla/readability |
+
+## Architecture
+
+```
+Main Process                              Renderer (SolidJS)
+├── TabManager (WebContentsView[])        ├── TabBar, AddressBar
+├── AgentRuntime (session + supervision)  ├── CommandBar (secondary surface)
+├── MCP server for external agents        ├── AI Sidebar (Supervisor/Bookmarks/Checkpoints/Chat)
+├── AI providers (Anthropic + OAI-compat) ├── DevTools Panel (Console/Network/Activity)
+├── Supervision, bookmarks, checkpoints   └── Signal stores (tabs, ai, ui)
+└── IPC Handlers ◄──contextBridge──► Preload API
+```
+
+Each browser tab is a separate `WebContentsView` managed by the main process. The browser chrome (SolidJS) runs in its own view layered on top. All communication between renderer and main goes through typed IPC channels via `contextBridge`.
+
+## Getting Started
+
+The installer:
+
+- clones or updates Vessel into `~/.local/share/vessel-browser`
+- installs dependencies and builds the app
+- creates a `vessel-browser` launcher in `~/.local/bin`
+- creates a `vessel-browser-launch` helper in `~/.local/bin`
+- creates a `vessel-browser-update` helper in `~/.local/bin`
+- creates a `vessel-browser-status` helper in `~/.local/bin`
+- creates a desktop entry for Linux app launchers
+- writes `~/.config/vessel/vessel-settings.json` with MCP port `3100`
+- writes `~/.config/vessel/mcp-http-snippet.json`
+- prints the exact HTTP MCP snippet to paste into your harness config
+
+The packaged AppImage path:
+
+- does not require a local Node/Electron toolchain
+- uses the packaged Vessel app icon and metadata
+- is the recommended path for early adopters who just want to run Vessel
+
+After install:
+
+```bash
+vessel-browser
+```
+
+```bash
+# Install dependencies
+npm install
+
+# If Electron download fails, use a mirror:
+ELECTRON_MIRROR="https://npmmirror.com/mirrors/electron/" npm install
+
+# Development (with HMR)
+npm run dev
+
+# Production build
+npm run build
+
+# Smoke-test the MVP release path
+npm run smoke:test
+
+# Package an unpacked Linux app
+npm run dist:dir
+
+# Package a Linux AppImage
+npm run dist
+```
+
+Notes:
+
+- `npm run dev` still launches the stock Electron binary, so Linux may continue showing the default Electron gear icon in development
+- packaged builds created with `npm run dist` / `npm run dist:dir` use the Vessel app icon
+- the tracked smoke test runs typecheck, build, and the Electron navigation regression harness
+- for headless CI, run the smoke test under `xvfb-run -a npm run smoke:test`
+
+### Setting up Vessel for Hermes Agent or OpenClaw
+
+Vessel is designed to act as the browser runtime that your external agent harness drives.
+
+1. Launch Vessel
+2. Open Settings (`Ctrl+,`) to confirm MCP status, copy the endpoint, or change the MCP port
+3. Optional: set an Obsidian vault path or session preferences
+4. Start Hermes Agent or OpenClaw and configure it to connect to Vessel's MCP endpoint at `http://127.0.0.1:<mcpPort>/mcp`
+5. Use the Supervisor panel in Vessel's sidebar to pause the agent, change approval mode, review pending approvals, checkpoint, or restore the browser session while the harness runs
+6. Use the Bookmarks panel to organize saved pages into folders and expose those bookmarks back to the agent over MCP
+
+Notes:
+
+- Vessel exposes browser control to external agents through its local MCP server
+- The default MCP port is `3100`
+- Hermes Agent and OpenClaw should treat Vessel as the persistent, human-visible browser rather than launching their own separate browser session
+- Vessel supports a built-in Chat tab with configurable AI provider; open Settings (`Ctrl+,`) and enable Chat Assistant to set a provider and model
+- Approval policy is controlled live from the sidebar Supervisor panel rather than a separate global settings screen
+- Settings now show MCP runtime status, active endpoint, startup warnings, and allow changing the MCP port with an immediate server restart
+- Agents can selectively disable ad blocking for a problematic tab, reload, retry the flow, and turn blocking back on later
+- Agents can persist authenticated state with named sessions, for example `github-logged-in`, and reload that state in later runs
+- The intended control plane is an external harness driving Vessel through MCP
+- If you set an Obsidian vault path in Settings, harnesses can write markdown notes directly into that vault via Vessel memory MCP tools
+
+Initial memory tools:
+
+- `vessel_memory_note_create`
+- `vessel_memory_append`
+- `vessel_memory_list`
+- `vessel_memory_search`
+- `vessel_memory_page_capture`
+- `vessel_memory_link_bookmark`
+
+Bookmark and folder tools exposed today include:
+
+- `vessel_bookmark_list`
+- `vessel_bookmark_search`
+- `vessel_bookmark_open`
+- `vessel_bookmark_save`
+- `vessel_bookmark_remove`
+- `vessel_create_folder`
+- `vessel_folder_rename`
+- `vessel_folder_remove`
+
+Page interaction and recovery tools exposed today include:
+
+- `vessel_extract_content`
+- `vessel_read_page`
+- `vessel_scroll`
+- `vessel_dismiss_popup`
+- `vessel_set_ad_blocking`
+- `vessel_wait_for`
+
+Named session tools exposed today include:
+
+- `vessel_save_session`
+- `vessel_load_session`
+- `vessel_list_sessions`
+- `vessel_delete_session`
+
+Session files are sensitive because they may contain login cookies and tokens. Vessel stores them under the app user-data directory with restrictive file permissions.
+
+Notable extraction modes include:
+
+- `visible_only` — only currently visible, in-viewport, unobstructed interactive elements plus active overlays
+- `results_only` — likely primary search/result links only
+- `full` / `summary` / `interactives_only` / `forms_only` / `text_only`
+
+The extraction output can distinguish:
+
+- active blocking overlays
+- dormant consent/modal UI present in the DOM but not active for the current session or region
+
+Generic HTTP MCP config:
+
+```json
+{
+  "mcpServers": {
+    "vessel": {
+      "type": "http",
+      "url": "http://127.0.0.1:3100/mcp"
+    }
+  }
+}
+```
+
+Hermes Agent `config.yaml` MCP config:
+
+```yaml
+mcp_servers:
+  vessel:
+    url: "http://127.0.0.1:3100/mcp"
+    timeout: 180
+    connect_timeout: 30
+```
+
+## Configuration 
+
+The installer writes both snippets to:
+
+- `~/.config/vessel/mcp-http-snippet.json`
+- `~/.config/vessel/mcp-hermes-snippet.yaml`
+
+It also installs a helper command:
+
+```bash
+vessel-browser-mcp
+```
+
+Helper examples:
+
+```bash
+# Generic JSON snippet
+vessel-browser-mcp
+
+# Hermes-ready YAML snippet
+vessel-browser-mcp --format hermes
+
+# Raw MCP endpoint URL
+vessel-browser-mcp --format url
+```
+
+Source install update helpers:
+
+```bash
+# Check whether a source-install update is available
+vessel-browser-update --check
+
+# Fetch, rebuild, and update the local source install
+vessel-browser-update
+```
+
+Status helper:
+
+```bash
+# Human-readable local install + MCP status
+vessel-browser-status
+
+# Machine-readable status for harnesses
+vessel-browser-status --json
+```
+
+Smart launch helper:
+
+```bash
+# Launch Vessel using the best available local install
+vessel-browser-launch
+
+# Show the chosen launch path without starting anything
+vessel-browser-launch --dry-run
+```
+
+`vessel-browser-launch` prefers a healthy source install and falls back to the newest local AppImage when the source install is likely blocked by Electron sandbox permissions.
 
 ## Keyboard Shortcuts
 
 | Shortcut | Action |
 |----------|--------|
 | `Ctrl+L` | AI Command Bar |
-| `Ctrl+H` | Capture current text selection as a highlight |
-| `Ctrl+Shift+L` | Toggle Supervisor Sidebar |
+| `Ctrl+Shift+L` | Toggle AI Sidebar |
 | `Ctrl+Shift+F` | Toggle Focus Mode |
+| `F12` | Toggle Dev Tools Panel |
 | `Ctrl+T` | New Tab |
 | `Ctrl+W` | Close Tab |
 | `Ctrl+,` | Settings |
+
+## Project Structure
+
+```
+src/
+├── main/                 # Electron main process
+│   ├── ai/               # Agent tools, query flow, and AI provider implementations
+│   ├── tabs/             # Tab + TabManager (WebContentsView)
+│   ├── agent/            # Agent runtime, checkpoints, supervision
+│   ├── content/          # Readability extraction, reader mode
+│   ├── config/           # Settings persistence
+│   ├── ipc/              # IPC handler registry
+│   ├── mcp/              # MCP server for external agent control
+│   ├── devtools/         # CDP session management for Dev Tools panel
+│   ├── window.ts         # Window layout manager
+│   └── index.ts          # App entry point
+├── preload/              # contextBridge scripts
+│   ├── index.ts          # Chrome UI preload
+│   └── content-script.ts # Web page preload (readability)
+├── renderer/             # SolidJS browser UI
+│   └── src/
+│       ├── components/
+│       │   ├── chrome/   # TitleBar, TabBar, AddressBar
+│       │   ├── ai/       # CommandBar, Sidebar (Supervisor/Bookmarks/Checkpoints/Chat)
+│       │   ├── devtools/ # DevTools panel (Console, Network, Activity)
+│       │   └── shared/   # Settings panel
+│       ├── stores/       # SolidJS signal stores
+│       ├── styles/       # Theme, global CSS
+│       └── lib/          # Keybindings
+└── shared/               # Types + IPC channel constants
+```
+
+## Design Principles
+
+- **Agent first** — the browser is the agent's operating surface, not just a human tool with automation bolted on
+- **Human visible** — the UI should make agent behavior easy to follow, audit, and steer
+- **Persistent by default** — browser state should survive long-running workflows and repeated sessions
+- **Content first** — chrome is 110px, everything else is your page
+- **Easy on the eyes** — warm dark grays, muted text, no visual noise
+- **Linux-native** — frameless window, system font fallbacks, XDG conventions
 
 ## License
 

--- a/bin/vessel-browser.js
+++ b/bin/vessel-browser.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const { spawn } = require("child_process");
+const path = require("path");
+
+const electronPath = require("electron");
+const appPath = path.resolve(__dirname, "..");
+
+const child = spawn(electronPath, [appPath], {
+  stdio: "inherit",
+  env: { ...process.env, ELECTRON_IS_NPM_LAUNCH: "1" },
+});
+
+child.on("close", (code) => {
+  process.exit(code ?? 0);
+});

--- a/bin/vessel-browser.js
+++ b/bin/vessel-browser.js
@@ -2,7 +2,17 @@
 const { spawn } = require("child_process");
 const path = require("path");
 
-const electronPath = require("electron");
+let electronPath;
+try {
+  electronPath = require("electron");
+} catch {
+  console.error(
+    'Error: "electron" is required but not installed.\n' +
+    "Install it with: npm install -g electron"
+  );
+  process.exit(1);
+}
+
 const appPath = path.resolve(__dirname, "..");
 
 const child = spawn(electronPath, [appPath], {

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     plugins: [externalizeDepsPlugin()],
   },
   preload: {
-    plugins: [externalizeDepsPlugin()],
+    plugins: [externalizeDepsPlugin({ exclude: ['@mozilla/readability'] })],
     build: {
       rollupOptions: {
         input: {

--- a/package.json
+++ b/package.json
@@ -46,9 +46,13 @@
     "type": "git",
     "url": "https://github.com/unmodeled-tyler/quanta-vessel-browser.git"
   },
+  "peerDependencies": {
+    "electron": ">=30.0.0"
+  },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
     "@types/node": "^25.3.5",
+    "electron": "^40.8.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "solid-js": "^1.9.11",
@@ -61,7 +65,6 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@mozilla/readability": "^0.6.0",
     "dompurify": "^3.3.2",
-    "electron": "^40.8.0",
     "linkedom": "^0.18.12",
     "openai": "^6.27.0",
     "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -1,8 +1,19 @@
 {
-  "name": "vessel",
+  "name": "@quanta-intellect/vessel-browser",
   "version": "0.1.0",
-  "description": "AI-native web browser for Linux",
+  "description": "AI-native web browser for Linux — persistent browser runtime for autonomous agents with human supervision",
   "main": "./out/main/index.js",
+  "bin": {
+    "vessel-browser": "./bin/vessel-browser.js"
+  },
+  "files": [
+    "out/**/*",
+    "bin/**/*",
+    "resources/vessel-icon.png",
+    "package.json",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
@@ -10,6 +21,7 @@
     "dist:dir": "npm run build && electron-builder --linux dir --publish never",
     "preview": "electron-vite preview",
     "typecheck": "tsc --noEmit",
+    "prepublishOnly": "npm run build",
     "test:navigation-regression": "electron --no-sandbox --disable-setuid-sandbox scripts/run-navigation-regression.mjs",
     "smoke:test": "node scripts/smoke-test.mjs"
   },
@@ -22,14 +34,21 @@
     "linux",
     "mcp",
     "model-context-protocol",
-    "solidjs"
+    "solidjs",
+    "vessel"
   ],
-  "author": "",
+  "author": "Quanta Intellect",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/unmodeled-tyler/quanta-vessel-browser.git"
+  },
   "devDependencies": {
     "@types/dompurify": "^3.0.5",
     "@types/node": "^25.3.5",
-    "electron": "^40.8.0",
     "electron-builder": "^26.8.1",
     "electron-vite": "^5.0.0",
     "solid-js": "^1.9.11",
@@ -42,6 +61,7 @@
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@mozilla/readability": "^0.6.0",
     "dompurify": "^3.3.2",
+    "electron": "^40.8.0",
     "linkedom": "^0.18.12",
     "openai": "^6.27.0",
     "zod": "^4.3.6"

--- a/src/main/ai/commands.ts
+++ b/src/main/ai/commands.ts
@@ -1,4 +1,5 @@
 import type { AIProvider } from "./provider";
+import type { AIMessage } from "../../shared/types";
 import {
   buildSummarizePrompt,
   buildQuestionPrompt,
@@ -20,6 +21,7 @@ export async function handleAIQuery(
   onEnd: () => void,
   tabManager?: TabManager,
   runtime?: AgentRuntime,
+  history?: AIMessage[],
 ): Promise<void> {
   const lowerQuery = query.toLowerCase().trim();
 
@@ -86,6 +88,7 @@ Instructions:
         onChunk,
         (name, args) => executeAction(name, args, actionCtx),
         onEnd,
+        history,
       );
       return;
     } catch {
@@ -112,5 +115,5 @@ Instructions:
     prompt = buildGeneralPrompt(query);
   }
 
-  await provider.streamQuery(prompt.system, prompt.user, onChunk, onEnd);
+  await provider.streamQuery(prompt.system, prompt.user, onChunk, onEnd, history);
 }

--- a/src/main/ai/provider-anthropic.ts
+++ b/src/main/ai/provider-anthropic.ts
@@ -1,5 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import type { AIProvider } from "./provider";
+import type { AIMessage } from "../../shared/types";
 
 const MAX_AGENT_ITERATIONS = 15;
 
@@ -18,8 +19,14 @@ export class AnthropicProvider implements AIProvider {
     userMessage: string,
     onChunk: (text: string) => void,
     onEnd: () => void,
+    history?: AIMessage[],
   ): Promise<void> {
     this.abortController = new AbortController();
+
+    const messages: Anthropic.MessageParam[] = [
+      ...(history ?? []).map((m) => ({ role: m.role, content: m.content } as Anthropic.MessageParam)),
+      { role: "user", content: userMessage },
+    ];
 
     try {
       const stream = this.client.messages.stream(
@@ -27,7 +34,7 @@ export class AnthropicProvider implements AIProvider {
           model: this.model,
           max_tokens: 4096,
           system: systemPrompt,
-          messages: [{ role: "user", content: userMessage }],
+          messages,
         },
         { signal: this.abortController.signal },
       );

--- a/src/main/ai/provider-anthropic.ts
+++ b/src/main/ai/provider-anthropic.ts
@@ -64,10 +64,12 @@ export class AnthropicProvider implements AIProvider {
     onChunk: (text: string) => void,
     onToolCall: (name: string, args: Record<string, any>) => Promise<string>,
     onEnd: () => void,
+    history?: AIMessage[],
   ): Promise<void> {
     this.abortController = new AbortController();
 
     const messages: Anthropic.MessageParam[] = [
+      ...(history ?? []).map((m) => ({ role: m.role, content: m.content } as Anthropic.MessageParam)),
       { role: "user", content: userMessage },
     ];
 

--- a/src/main/ai/provider-openai.ts
+++ b/src/main/ai/provider-openai.ts
@@ -1,6 +1,6 @@
 import OpenAI from 'openai';
 import type { AIProvider } from './provider';
-import type { ProviderConfig } from '../../shared/types';
+import type { AIMessage, ProviderConfig } from '../../shared/types';
 import { PROVIDERS } from './providers';
 
 export class OpenAICompatProvider implements AIProvider {
@@ -25,18 +25,22 @@ export class OpenAICompatProvider implements AIProvider {
     userMessage: string,
     onChunk: (text: string) => void,
     onEnd: () => void,
+    history?: AIMessage[],
   ): Promise<void> {
     this.abortController = new AbortController();
+
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: systemPrompt },
+      ...(history ?? []).map((m) => ({ role: m.role, content: m.content } as OpenAI.Chat.ChatCompletionMessageParam)),
+      { role: 'user', content: userMessage },
+    ];
 
     try {
       const stream = await this.client.chat.completions.create(
         {
           model: this.model,
           stream: true,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            { role: 'user', content: userMessage },
-          ],
+          messages,
         },
         { signal: this.abortController.signal },
       );

--- a/src/main/ai/provider-openai.ts
+++ b/src/main/ai/provider-openai.ts
@@ -1,7 +1,21 @@
 import OpenAI from 'openai';
+import type Anthropic from '@anthropic-ai/sdk';
 import type { AIProvider } from './provider';
 import type { AIMessage, ProviderConfig } from '../../shared/types';
 import { PROVIDERS } from './providers';
+
+const MAX_AGENT_ITERATIONS = 15;
+
+function toOpenAITools(tools: Anthropic.Tool[]): OpenAI.ChatCompletionTool[] {
+  return tools.map((t) => ({
+    type: 'function' as const,
+    function: {
+      name: t.name,
+      description: t.description ?? '',
+      parameters: t.input_schema as Record<string, unknown>,
+    },
+  }));
+}
 
 export class OpenAICompatProvider implements AIProvider {
   private client: OpenAI;
@@ -14,7 +28,7 @@ export class OpenAICompatProvider implements AIProvider {
       config.baseUrl || meta?.defaultBaseUrl || 'https://api.openai.com/v1';
 
     this.client = new OpenAI({
-      apiKey: config.apiKey || 'ollama', // Ollama doesn't need a real key
+      apiKey: config.apiKey || 'ollama',
       baseURL,
     });
     this.model = config.model || meta?.defaultModel || 'gpt-4o';
@@ -49,6 +63,114 @@ export class OpenAICompatProvider implements AIProvider {
         const delta = chunk.choices[0]?.delta?.content;
         if (delta) {
           onChunk(delta);
+        }
+      }
+    } catch (err: any) {
+      if (err.name !== 'AbortError') {
+        onChunk(`\n\n[Error: ${err.message}]`);
+      }
+    } finally {
+      this.abortController = null;
+      onEnd();
+    }
+  }
+
+  async streamAgentQuery(
+    systemPrompt: string,
+    userMessage: string,
+    tools: Anthropic.Tool[],
+    onChunk: (text: string) => void,
+    onToolCall: (name: string, args: Record<string, any>) => Promise<string>,
+    onEnd: () => void,
+    history?: AIMessage[],
+  ): Promise<void> {
+    this.abortController = new AbortController();
+    const openAITools = toOpenAITools(tools);
+
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: systemPrompt },
+      ...(history ?? []).map((m) => ({ role: m.role, content: m.content } as OpenAI.Chat.ChatCompletionMessageParam)),
+      { role: 'user', content: userMessage },
+    ];
+
+    try {
+      for (let i = 0; i < MAX_AGENT_ITERATIONS; i++) {
+        // Accumulate text and tool calls across streamed chunks
+        let textAccum = '';
+        const toolCallAccums: Record<number, { id: string; name: string; argsJson: string }> = {};
+        let finishReason: string | null = null;
+
+        const stream = await this.client.chat.completions.create(
+          {
+            model: this.model,
+            stream: true,
+            messages,
+            tools: openAITools,
+            tool_choice: 'auto',
+          },
+          { signal: this.abortController.signal },
+        );
+
+        for await (const chunk of stream) {
+          const choice = chunk.choices[0];
+          if (!choice) continue;
+
+          const delta = choice.delta;
+          if (choice.finish_reason) finishReason = choice.finish_reason;
+
+          if (delta.content) {
+            textAccum += delta.content;
+            onChunk(delta.content);
+          }
+
+          if (delta.tool_calls) {
+            for (const tc of delta.tool_calls) {
+              const idx = tc.index;
+              if (!toolCallAccums[idx]) {
+                toolCallAccums[idx] = { id: '', name: '', argsJson: '' };
+              }
+              if (tc.id) toolCallAccums[idx].id = tc.id;
+              if (tc.function?.name) toolCallAccums[idx].name += tc.function.name;
+              if (tc.function?.arguments) toolCallAccums[idx].argsJson += tc.function.arguments;
+            }
+          }
+        }
+
+        const toolCalls = Object.values(toolCallAccums);
+
+        // Build assistant message for history
+        const assistantMsg: OpenAI.Chat.ChatCompletionAssistantMessageParam = {
+          role: 'assistant',
+          content: textAccum || null,
+          ...(toolCalls.length > 0 && {
+            tool_calls: toolCalls.map((tc) => ({
+              id: tc.id,
+              type: 'function' as const,
+              function: { name: tc.name, arguments: tc.argsJson },
+            })),
+          }),
+        };
+        messages.push(assistantMsg);
+
+        // If no tool calls or stop, we're done
+        if (finishReason !== 'tool_calls' || toolCalls.length === 0) break;
+
+        // Execute each tool and collect results
+        for (const tc of toolCalls) {
+          let args: Record<string, any> = {};
+          try {
+            args = JSON.parse(tc.argsJson || '{}');
+          } catch {
+            // leave args empty
+          }
+          const argSummary = args.url || args.text || args.direction || '';
+          onChunk(`\n\`[${tc.name}${argSummary ? ': ' + argSummary : ''}]\` `);
+          const result = await onToolCall(tc.name, args);
+          messages.push({
+            role: 'tool',
+            tool_call_id: tc.id,
+            content: result,
+          });
         }
       }
     } catch (err: any) {

--- a/src/main/ai/provider.ts
+++ b/src/main/ai/provider.ts
@@ -1,6 +1,6 @@
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
-import type { ProviderConfig } from "../../shared/types";
+import type { AIMessage, ProviderConfig } from "../../shared/types";
 import { AnthropicProvider } from "./provider-anthropic";
 import { OpenAICompatProvider } from "./provider-openai";
 import { PROVIDERS } from "./providers";
@@ -11,6 +11,7 @@ export interface AIProvider {
     userMessage: string,
     onChunk: (text: string) => void,
     onEnd: () => void,
+    history?: AIMessage[],
   ): Promise<void>;
 
   streamAgentQuery?(

--- a/src/main/ai/provider.ts
+++ b/src/main/ai/provider.ts
@@ -21,6 +21,7 @@ export interface AIProvider {
     onChunk: (text: string) => void,
     onToolCall: (name: string, args: Record<string, any>) => Promise<string>,
     onEnd: () => void,
+    history?: AIMessage[],
   ): Promise<void>;
 
   cancel(): void;

--- a/src/main/config/settings.ts
+++ b/src/main/config/settings.ts
@@ -13,6 +13,7 @@ const defaults: VesselSettings = {
   obsidianVaultPath: "",
   approvalMode: "confirm-dangerous",
   agentTranscriptMode: "summary",
+  chatProvider: null,
 };
 
 let settings: VesselSettings | null = null;

--- a/src/main/devtools/manager.ts
+++ b/src/main/devtools/manager.ts
@@ -1,0 +1,38 @@
+import type { TabManager } from "../tabs/tab-manager";
+import { DevToolsSession } from "./session";
+
+const sessions = new Map<string, DevToolsSession>();
+
+export function getOrCreateSession(tabManager: TabManager): DevToolsSession {
+  const tabId = tabManager.getActiveTabId();
+  const tab = tabManager.getActiveTab();
+  if (!tabId || !tab) {
+    throw new Error("No active tab");
+  }
+
+  const existing = sessions.get(tabId);
+  if (existing) return existing;
+
+  const session = new DevToolsSession(tabId, tab.view.webContents);
+  sessions.set(tabId, session);
+  return session;
+}
+
+export function getSession(tabId: string): DevToolsSession | undefined {
+  return sessions.get(tabId);
+}
+
+export function destroySession(tabId: string): void {
+  const session = sessions.get(tabId);
+  if (session) {
+    session.destroy();
+    sessions.delete(tabId);
+  }
+}
+
+export function destroyAllSessions(): void {
+  for (const session of sessions.values()) {
+    session.destroy();
+  }
+  sessions.clear();
+}

--- a/src/main/devtools/session.ts
+++ b/src/main/devtools/session.ts
@@ -172,7 +172,10 @@ export class DevToolsSession {
   async ensureNetworkDomain(): Promise<void> {
     await this.ensureAttached();
     if (this.networkDomainEnabled) return;
-    await this.cdpSend("Network.enable");
+    await this.cdpSend("Network.enable", {
+      maxTotalBufferSize: 10 * 1024 * 1024,
+      maxResourceBufferSize: 5 * 1024 * 1024,
+    });
     this.networkDomainEnabled = true;
   }
 
@@ -335,19 +338,31 @@ export class DevToolsSession {
     value: string | null,
   ): Promise<string> {
     await this.ensureAttached();
-    const doc = await this.cdpSend("DOM.getDocument", { depth: 0 });
-    const result = await this.cdpSend("DOM.querySelector", {
-      nodeId: doc.root.nodeId as number,
-      selector,
+    const selectorJson = JSON.stringify(selector);
+    const nameJson = JSON.stringify(name);
+    const expression =
+      value === null
+        ? `(function(){var el=document.querySelector(${selectorJson});if(!el)throw new Error('No element found for selector: '+${selectorJson});el.removeAttribute(${nameJson});return true;})()`
+        : `(function(){var el=document.querySelector(${selectorJson});if(!el)throw new Error('No element found for selector: '+${selectorJson});el.setAttribute(${nameJson},${JSON.stringify(value)});return true;})()`;
+
+    const response = await this.cdpSend("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: false,
     });
-    const nodeId = result.nodeId as number;
-    if (!nodeId) throw new Error(`No element found for selector: ${selector}`);
+
+    if (response.exceptionDetails) {
+      const ex = response.exceptionDetails as Record<string, unknown>;
+      const desc =
+        (ex.exception as Record<string, unknown>)?.description ??
+        (ex.exception as Record<string, unknown>)?.value ??
+        "Failed to modify DOM";
+      throw new Error(String(desc));
+    }
 
     if (value === null) {
-      await this.cdpSend("DOM.removeAttribute", { nodeId, name });
       return `Removed attribute "${name}" from ${selector}`;
     }
-    await this.cdpSend("DOM.setAttributeValue", { nodeId, name, value });
     return `Set ${selector} ${name}="${value}"`;
   }
 

--- a/src/main/devtools/session.ts
+++ b/src/main/devtools/session.ts
@@ -1,0 +1,861 @@
+import type { WebContents } from "electron";
+import type {
+  ConsoleEntry,
+  ComputedStyle,
+  DomNodeInfo,
+  ErrorEntry,
+  NetworkEntry,
+  PerformanceSnapshot,
+  StorageData,
+} from "./types";
+
+const MAX_CONSOLE_ENTRIES = 500;
+const MAX_NETWORK_ENTRIES = 200;
+const MAX_ERROR_ENTRIES = 200;
+
+const MAX_PENDING_REQUESTS = 500;
+
+export class DevToolsSession {
+  private attached = false;
+  private attachingPromise: Promise<void> | null = null;
+  private consoleDomainEnabled = false;
+  private networkDomainEnabled = false;
+  private cssDomainEnabled = false;
+  private runtimeExceptionsEnabled = false;
+
+  private consoleBuffer: ConsoleEntry[] = [];
+  private networkBuffer: NetworkEntry[] = [];
+  private errorBuffer: ErrorEntry[] = [];
+  private entryCounter = 0;
+
+  // Track in-flight network requests for matching response data
+  private pendingRequests = new Map<
+    string,
+    { entry: NetworkEntry }
+  >();
+
+  // Named handlers so we can remove them on detach/destroy (fixes listener leak)
+  private readonly onDetach = () => {
+    this.attached = false;
+    this.consoleDomainEnabled = false;
+    this.networkDomainEnabled = false;
+    this.cssDomainEnabled = false;
+    this.runtimeExceptionsEnabled = false;
+    this.pendingRequests.clear();
+  };
+
+  private readonly onMessage = (
+    _event: Electron.Event,
+    method: string,
+    params: Record<string, unknown>,
+  ) => {
+    this.handleCdpEvent(method, params);
+  };
+
+  constructor(
+    readonly tabId: string,
+    private readonly wc: WebContents,
+  ) {}
+
+  get isAttached(): boolean {
+    return this.attached;
+  }
+
+  async ensureAttached(): Promise<void> {
+    if (this.attached) return;
+    // Serialize concurrent attach calls to prevent duplicate listeners
+    if (this.attachingPromise) return this.attachingPromise;
+    this.attachingPromise = this.doAttach().finally(() => {
+      this.attachingPromise = null;
+    });
+    return this.attachingPromise;
+  }
+
+  private async doAttach(): Promise<void> {
+    if (this.attached) return;
+    if (this.wc.isDestroyed()) {
+      throw new Error("WebContents is destroyed");
+    }
+    try {
+      this.wc.debugger.attach("1.3");
+    } catch (err) {
+      // Already attached is fine
+      if (
+        !(err instanceof Error) ||
+        !err.message.includes("Already attached")
+      ) {
+        throw err;
+      }
+    }
+    this.attached = true;
+    this.wc.debugger.on("detach", this.onDetach);
+    this.wc.debugger.on("message", this.onMessage);
+  }
+
+  private removeListeners(): void {
+    try {
+      this.wc.debugger.removeListener("detach", this.onDetach);
+      this.wc.debugger.removeListener("message", this.onMessage);
+    } catch {
+      // WebContents may already be destroyed
+    }
+  }
+
+  detach(): void {
+    if (!this.attached) {
+      this.removeListeners();
+      return;
+    }
+    this.removeListeners();
+    try {
+      this.wc.debugger.detach();
+    } catch {
+      // Already detached
+    }
+    this.attached = false;
+    this.consoleDomainEnabled = false;
+    this.networkDomainEnabled = false;
+    this.cssDomainEnabled = false;
+    this.runtimeExceptionsEnabled = false;
+    this.pendingRequests.clear();
+  }
+
+  destroy(): void {
+    this.detach();
+    this.consoleBuffer = [];
+    this.networkBuffer = [];
+    this.errorBuffer = [];
+    this.pendingRequests.clear();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Console
+  // ---------------------------------------------------------------------------
+
+  async ensureConsoleDomain(): Promise<void> {
+    await this.ensureAttached();
+    if (this.consoleDomainEnabled) return;
+    await this.cdpSend("Console.enable");
+    await this.cdpSend("Runtime.enable");
+    this.consoleDomainEnabled = true;
+  }
+
+  getConsoleLogs(options?: {
+    level?: string;
+    limit?: number;
+    search?: string;
+  }): ConsoleEntry[] {
+    let entries = this.consoleBuffer;
+    if (options?.level) {
+      entries = entries.filter((e) => e.level === options.level);
+    }
+    if (options?.search) {
+      const term = options.search.toLowerCase();
+      entries = entries.filter((e) => e.text.toLowerCase().includes(term));
+    }
+    if (options?.limit && options.limit > 0) {
+      entries = entries.slice(-options.limit);
+    }
+    return entries;
+  }
+
+  clearConsoleLogs(): number {
+    const count = this.consoleBuffer.length;
+    this.consoleBuffer = [];
+    return count;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Network
+  // ---------------------------------------------------------------------------
+
+  async ensureNetworkDomain(): Promise<void> {
+    await this.ensureAttached();
+    if (this.networkDomainEnabled) return;
+    await this.cdpSend("Network.enable");
+    this.networkDomainEnabled = true;
+  }
+
+  getNetworkLog(options?: {
+    urlPattern?: string;
+    method?: string;
+    statusRange?: { min?: number; max?: number };
+    limit?: number;
+  }): NetworkEntry[] {
+    let entries = this.networkBuffer;
+    if (options?.urlPattern) {
+      try {
+        const regex = new RegExp(options.urlPattern, "i");
+        entries = entries.filter((e) => regex.test(e.url));
+      } catch {
+        const term = options.urlPattern.toLowerCase();
+        entries = entries.filter((e) => e.url.toLowerCase().includes(term));
+      }
+    }
+    if (options?.method) {
+      const method = options.method.toUpperCase();
+      entries = entries.filter((e) => e.method === method);
+    }
+    if (options?.statusRange) {
+      const min = options.statusRange.min ?? 0;
+      const max = options.statusRange.max ?? 999;
+      entries = entries.filter(
+        (e) => e.status != null && e.status >= min && e.status <= max,
+      );
+    }
+    if (options?.limit && options.limit > 0) {
+      entries = entries.slice(-options.limit);
+    }
+    return entries;
+  }
+
+  async getNetworkResponseBody(
+    requestId: string,
+  ): Promise<{ body: string; base64Encoded: boolean } | { error: string }> {
+    await this.ensureNetworkDomain();
+    try {
+      const result = await this.cdpSend("Network.getResponseBody", {
+        requestId,
+      });
+      return {
+        body: result.body as string,
+        base64Encoded: result.base64Encoded as boolean,
+      };
+    } catch (err) {
+      return {
+        error: err instanceof Error ? err.message : "Failed to get body",
+      };
+    }
+  }
+
+  clearNetworkLog(): number {
+    const count = this.networkBuffer.length;
+    this.networkBuffer = [];
+    this.pendingRequests.clear();
+    return count;
+  }
+
+  // ---------------------------------------------------------------------------
+  // DOM
+  // ---------------------------------------------------------------------------
+
+  async queryDom(
+    selector: string,
+    options?: { includeHtml?: boolean },
+  ): Promise<DomNodeInfo[]> {
+    await this.ensureAttached();
+    const doc = await this.cdpSend("DOM.getDocument", { depth: 0 });
+    const rootNodeId = doc.root.nodeId as number;
+
+    const result = await this.cdpSend("DOM.querySelectorAll", {
+      nodeId: rootNodeId,
+      selector,
+    });
+    const nodeIds = result.nodeIds as number[];
+    if (!nodeIds || nodeIds.length === 0) return [];
+
+    const nodes: DomNodeInfo[] = [];
+    for (const nodeId of nodeIds.slice(0, 50)) {
+      try {
+        const desc = await this.cdpSend("DOM.describeNode", {
+          nodeId,
+          depth: 0,
+        });
+        const node = desc.node as Record<string, unknown>;
+        const attrs: Record<string, string> = {};
+        const rawAttrs = node.attributes as string[] | undefined;
+        if (rawAttrs) {
+          for (let i = 0; i < rawAttrs.length; i += 2) {
+            attrs[rawAttrs[i]] = rawAttrs[i + 1];
+          }
+        }
+
+        const info: DomNodeInfo = {
+          nodeId,
+          nodeType: node.nodeType as number,
+          nodeName: node.nodeName as string,
+          localName: node.localName as string,
+          attributes: attrs,
+          childCount: (node.childNodeCount as number) ?? 0,
+        };
+
+        if (options?.includeHtml) {
+          try {
+            const html = await this.cdpSend("DOM.getOuterHTML", { nodeId });
+            const outer = html.outerHTML as string;
+            info.outerHTML = outer.length > 5000 ? outer.slice(0, 5000) + "..." : outer;
+          } catch {
+            // Some nodes may not support getOuterHTML
+          }
+        }
+
+        nodes.push(info);
+      } catch {
+        // Skip nodes that fail to describe (e.g., stale nodeIds)
+      }
+    }
+    return nodes;
+  }
+
+  async ensureCssDomain(): Promise<void> {
+    await this.ensureAttached();
+    if (this.cssDomainEnabled) return;
+    await this.cdpSend("CSS.enable");
+    this.cssDomainEnabled = true;
+  }
+
+  async getComputedStyles(
+    selector: string,
+    properties?: string[],
+  ): Promise<ComputedStyle[]> {
+    await this.ensureAttached();
+    await this.ensureCssDomain();
+    const doc = await this.cdpSend("DOM.getDocument", { depth: 0 });
+    const result = await this.cdpSend("DOM.querySelector", {
+      nodeId: doc.root.nodeId as number,
+      selector,
+    });
+    const nodeId = result.nodeId as number;
+    if (!nodeId) throw new Error(`No element found for selector: ${selector}`);
+
+    const computed = await this.cdpSend("CSS.getComputedStyleForNode", {
+      nodeId,
+    });
+    let styles = (computed.computedStyle as Array<{ name: string; value: string }>) ?? [];
+    if (properties && properties.length > 0) {
+      const propSet = new Set(properties.map((p) => p.toLowerCase()));
+      styles = styles.filter((s) => propSet.has(s.name.toLowerCase()));
+    }
+    return styles.map((s) => ({ property: s.name, value: s.value }));
+  }
+
+  async modifyDomAttribute(
+    selector: string,
+    name: string,
+    value: string | null,
+  ): Promise<string> {
+    await this.ensureAttached();
+    const doc = await this.cdpSend("DOM.getDocument", { depth: 0 });
+    const result = await this.cdpSend("DOM.querySelector", {
+      nodeId: doc.root.nodeId as number,
+      selector,
+    });
+    const nodeId = result.nodeId as number;
+    if (!nodeId) throw new Error(`No element found for selector: ${selector}`);
+
+    if (value === null) {
+      await this.cdpSend("DOM.removeAttribute", { nodeId, name });
+      return `Removed attribute "${name}" from ${selector}`;
+    }
+    await this.cdpSend("DOM.setAttributeValue", { nodeId, name, value });
+    return `Set ${selector} ${name}="${value}"`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // JavaScript Execution
+  // ---------------------------------------------------------------------------
+
+  async executeJs(expression: string): Promise<{
+    result: string;
+    type: string;
+    exceptionDetails?: string;
+  }> {
+    await this.ensureAttached();
+    const response = await this.cdpSend("Runtime.evaluate", {
+      expression,
+      returnByValue: true,
+      awaitPromise: true,
+      generatePreview: true,
+      timeout: 10000,
+    });
+
+    const result = response.result as Record<string, unknown>;
+    const exceptionDetails = response.exceptionDetails as
+      | Record<string, unknown>
+      | undefined;
+
+    let resultText: string;
+    if (result.type === "undefined") {
+      resultText = "undefined";
+    } else if (result.value !== undefined) {
+      resultText =
+        typeof result.value === "string"
+          ? result.value
+          : JSON.stringify(result.value, null, 2);
+    } else if (result.description) {
+      resultText = result.description as string;
+    } else {
+      resultText = String(result.type);
+    }
+
+    return {
+      result: resultText.length > 10000
+        ? resultText.slice(0, 10000) + "..."
+        : resultText,
+      type: result.type as string,
+      exceptionDetails: exceptionDetails
+        ? formatExceptionDetails(exceptionDetails)
+        : undefined,
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Storage
+  // ---------------------------------------------------------------------------
+
+  async getStorage(
+    type: "localStorage" | "sessionStorage" | "cookie" | "indexedDB",
+  ): Promise<StorageData> {
+    // Storage is best accessed via executeJavaScript since CDP storage
+    // domains require security origins and are more complex
+    const origin = this.wc.getURL();
+
+    if (type === "cookie") {
+      const cookies = await this.wc.session.cookies.get({
+        url: origin,
+      });
+      const entries: Record<string, string> = {};
+      for (const cookie of cookies) {
+        entries[cookie.name] = cookie.value;
+      }
+      return { type, origin, entries };
+    }
+
+    if (type === "indexedDB") {
+      const result = await this.wc.executeJavaScript(`
+        (async function() {
+          try {
+            const dbs = await indexedDB.databases();
+            const entries = {};
+            for (const db of dbs) {
+              entries[db.name || '(unnamed)'] = 'version=' + (db.version || '?');
+            }
+            return entries;
+          } catch(e) { return { __error: e.message }; }
+        })()
+      `);
+      if (result?.__error) throw new Error(result.__error);
+      return { type, origin, entries: result ?? {} };
+    }
+
+    // localStorage / sessionStorage
+    const storageType = type === "localStorage" ? "localStorage" : "sessionStorage";
+    const result = await this.wc.executeJavaScript(`
+      (function() {
+        try {
+          const storage = window.${storageType};
+          const entries = {};
+          for (let i = 0; i < storage.length; i++) {
+            const key = storage.key(i);
+            entries[key] = storage.getItem(key);
+          }
+          return entries;
+        } catch(e) { return { __error: e.message }; }
+      })()
+    `);
+    if (result?.__error) throw new Error(result.__error);
+    return { type, origin, entries: result ?? {} };
+  }
+
+  async setStorage(
+    type: "localStorage" | "sessionStorage",
+    key: string,
+    value: string | null,
+  ): Promise<string> {
+    const storageType = type === "localStorage" ? "localStorage" : "sessionStorage";
+    if (value === null) {
+      await this.wc.executeJavaScript(
+        `window.${storageType}.removeItem(${JSON.stringify(key)})`,
+      );
+      return `Removed "${key}" from ${type}`;
+    }
+    await this.wc.executeJavaScript(
+      `window.${storageType}.setItem(${JSON.stringify(key)}, ${JSON.stringify(value)})`,
+    );
+    return `Set ${type}["${key}"] = ${value.length > 80 ? value.slice(0, 77) + "..." : value}`;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Performance
+  // ---------------------------------------------------------------------------
+
+  async getPerformanceSnapshot(): Promise<PerformanceSnapshot> {
+    const url = this.wc.getURL();
+    const perf = await this.wc.executeJavaScript(`
+      (function() {
+        const nav = performance.getEntriesByType('navigation')[0] || {};
+        const paint = performance.getEntriesByType('paint') || [];
+        const resources = performance.getEntriesByType('resource') || [];
+        const fp = paint.find(p => p.name === 'first-paint');
+        const fcp = paint.find(p => p.name === 'first-contentful-paint');
+
+        const byType = {};
+        let totalTransfer = 0;
+        let totalDecoded = 0;
+        for (const r of resources) {
+          const type = r.initiatorType || 'other';
+          byType[type] = (byType[type] || 0) + 1;
+          totalTransfer += r.transferSize || 0;
+          totalDecoded += r.decodedBodySize || 0;
+        }
+
+        let memory = null;
+        if (performance.memory) {
+          memory = {
+            jsHeapSizeLimit: performance.memory.jsHeapSizeLimit,
+            totalJSHeapSize: performance.memory.totalJSHeapSize,
+            usedJSHeapSize: performance.memory.usedJSHeapSize,
+          };
+        }
+
+        return {
+          timing: {
+            navigationStart: nav.startTime || 0,
+            domContentLoaded: nav.domContentLoadedEventEnd || null,
+            loadComplete: nav.loadEventEnd || null,
+            firstPaint: fp ? fp.startTime : null,
+            firstContentfulPaint: fcp ? fcp.startTime : null,
+          },
+          memory: memory,
+          resources: {
+            total: resources.length,
+            byType: byType,
+            totalTransferSize: totalTransfer,
+            totalDecodedSize: totalDecoded,
+          },
+        };
+      })()
+    `);
+
+    return {
+      timestamp: new Date().toISOString(),
+      pageUrl: url,
+      timing: perf.timing ?? {},
+      memory: perf.memory ?? undefined,
+      resources: perf.resources ?? { total: 0, byType: {}, totalTransferSize: 0, totalDecodedSize: 0 },
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Errors
+  // ---------------------------------------------------------------------------
+
+  async ensureErrorCapture(): Promise<void> {
+    await this.ensureAttached();
+    if (this.runtimeExceptionsEnabled) return;
+    await this.cdpSend("Runtime.enable");
+    await this.cdpSend("Runtime.setAsyncCallStackDepth", { maxDepth: 8 });
+    this.runtimeExceptionsEnabled = true;
+  }
+
+  getErrors(options?: { limit?: number; type?: string }): ErrorEntry[] {
+    let entries = this.errorBuffer;
+    if (options?.type) {
+      entries = entries.filter((e) => e.type === options.type);
+    }
+    if (options?.limit && options.limit > 0) {
+      entries = entries.slice(-options.limit);
+    }
+    return entries;
+  }
+
+  clearErrors(): number {
+    const count = this.errorBuffer.length;
+    this.errorBuffer = [];
+    return count;
+  }
+
+  // ---------------------------------------------------------------------------
+  // CDP helpers
+  // ---------------------------------------------------------------------------
+
+  private async cdpSend(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<Record<string, unknown>> {
+    if (!this.attached || this.wc.isDestroyed()) {
+      throw new Error("DevTools session is not attached");
+    }
+    return this.wc.debugger.sendCommand(method, params) as Promise<
+      Record<string, unknown>
+    >;
+  }
+
+  private handleCdpEvent(method: string, params: Record<string, unknown>): void {
+    switch (method) {
+      case "Console.messageAdded":
+        this.onConsoleMessage(params);
+        break;
+      case "Runtime.consoleAPICalled":
+        this.onRuntimeConsoleApi(params);
+        break;
+      case "Runtime.exceptionThrown":
+        this.onExceptionThrown(params);
+        break;
+      case "Network.requestWillBeSent":
+        this.onNetworkRequest(params);
+        break;
+      case "Network.responseReceived":
+        this.onNetworkResponse(params);
+        break;
+      case "Network.loadingFinished":
+        this.onNetworkFinished(params);
+        break;
+      case "Network.loadingFailed":
+        this.onNetworkFailed(params);
+        break;
+    }
+  }
+
+  // --- Console events ---
+
+  private onConsoleMessage(params: Record<string, unknown>): void {
+    const message = params.message as Record<string, unknown> | undefined;
+    if (!message) return;
+    this.pushConsoleEntry({
+      level: mapConsoleLevel(message.level as string),
+      text: (message.text as string) ?? "",
+      url: message.url as string | undefined,
+      line: message.line as number | undefined,
+      column: message.column as number | undefined,
+    });
+  }
+
+  private onRuntimeConsoleApi(params: Record<string, unknown>): void {
+    const type = params.type as string;
+    const args = params.args as Array<Record<string, unknown>> | undefined;
+    const trace = params.stackTrace as Record<string, unknown> | undefined;
+
+    const textParts: string[] = [];
+    if (args) {
+      for (const arg of args) {
+        if (arg.value !== undefined) {
+          textParts.push(
+            typeof arg.value === "string"
+              ? arg.value
+              : JSON.stringify(arg.value),
+          );
+        } else if (arg.description) {
+          textParts.push(arg.description as string);
+        } else {
+          textParts.push(`[${arg.type}]`);
+        }
+      }
+    }
+
+    let url: string | undefined;
+    let line: number | undefined;
+    let column: number | undefined;
+    const callFrames = trace?.callFrames as
+      | Array<Record<string, unknown>>
+      | undefined;
+    if (callFrames && callFrames.length > 0) {
+      url = callFrames[0].url as string | undefined;
+      line = callFrames[0].lineNumber as number | undefined;
+      column = callFrames[0].columnNumber as number | undefined;
+    }
+
+    this.pushConsoleEntry({
+      level: mapConsoleLevel(type),
+      text: textParts.join(" "),
+      url,
+      line,
+      column,
+      stackTrace: callFrames ? formatCallFrames(callFrames) : undefined,
+    });
+  }
+
+  private pushConsoleEntry(
+    data: Omit<ConsoleEntry, "id" | "timestamp">,
+  ): void {
+    const entry: ConsoleEntry = {
+      id: ++this.entryCounter,
+      timestamp: new Date().toISOString(),
+      ...data,
+    };
+    this.consoleBuffer.push(entry);
+    if (this.consoleBuffer.length > MAX_CONSOLE_ENTRIES) {
+      this.consoleBuffer = this.consoleBuffer.slice(-MAX_CONSOLE_ENTRIES);
+    }
+  }
+
+  // --- Network events ---
+
+  private onNetworkRequest(params: Record<string, unknown>): void {
+    const requestId = params.requestId as string;
+    const request = params.request as Record<string, unknown>;
+    const type = params.type as string | undefined;
+    const timestamp = params.timestamp as number | undefined;
+
+    const entry: NetworkEntry = {
+      id: ++this.entryCounter,
+      requestId,
+      timestamp: new Date().toISOString(),
+      method: (request.method as string) ?? "GET",
+      url: (request.url as string) ?? "",
+      resourceType: type,
+      requestHeaders: request.headers as Record<string, string> | undefined,
+      timing: {
+        startTime: timestamp ?? Date.now() / 1000,
+      },
+    };
+
+    this.networkBuffer.push(entry);
+    if (this.networkBuffer.length > MAX_NETWORK_ENTRIES) {
+      this.networkBuffer = this.networkBuffer.slice(-MAX_NETWORK_ENTRIES);
+    }
+
+    // Cap pending requests to prevent unbounded growth from cancelled requests
+    if (this.pendingRequests.size >= MAX_PENDING_REQUESTS) {
+      const oldest = this.pendingRequests.keys().next().value;
+      if (oldest !== undefined) this.pendingRequests.delete(oldest);
+    }
+    this.pendingRequests.set(requestId, { entry });
+  }
+
+  private onNetworkResponse(params: Record<string, unknown>): void {
+    const requestId = params.requestId as string;
+    const response = params.response as Record<string, unknown>;
+    const pending = this.pendingRequests.get(requestId);
+    if (!pending) return;
+
+    pending.entry.status = response.status as number;
+    pending.entry.statusText = response.statusText as string | undefined;
+    pending.entry.mimeType = response.mimeType as string | undefined;
+    pending.entry.responseHeaders = response.headers as
+      | Record<string, string>
+      | undefined;
+    pending.entry.fromCache = response.fromDiskCache === true ||
+      response.fromServiceWorker === true;
+
+    const contentLength = response.headers
+      ? ((response.headers as Record<string, string>)["content-length"] ??
+        (response.headers as Record<string, string>)["Content-Length"])
+      : undefined;
+    if (contentLength) {
+      pending.entry.contentLength = parseInt(contentLength, 10) || undefined;
+    }
+  }
+
+  private onNetworkFinished(params: Record<string, unknown>): void {
+    const requestId = params.requestId as string;
+    const timestamp = params.timestamp as number | undefined;
+    const pending = this.pendingRequests.get(requestId);
+    if (!pending) return;
+
+    if (timestamp && pending.entry.timing) {
+      pending.entry.timing.endTime = timestamp;
+      pending.entry.timing.durationMs = Math.round(
+        (timestamp - pending.entry.timing.startTime) * 1000,
+      );
+    }
+    pending.entry.contentLength =
+      pending.entry.contentLength ??
+      ((params.encodedDataLength as number) || undefined);
+    this.pendingRequests.delete(requestId);
+  }
+
+  private onNetworkFailed(params: Record<string, unknown>): void {
+    const requestId = params.requestId as string;
+    const pending = this.pendingRequests.get(requestId);
+    if (!pending) return;
+
+    pending.entry.error =
+      (params.errorText as string) ?? "Request failed";
+    const timestamp = params.timestamp as number | undefined;
+    if (timestamp && pending.entry.timing) {
+      pending.entry.timing.endTime = timestamp;
+      pending.entry.timing.durationMs = Math.round(
+        (timestamp - pending.entry.timing.startTime) * 1000,
+      );
+    }
+    this.pendingRequests.delete(requestId);
+  }
+
+  // --- Error events ---
+
+  private onExceptionThrown(params: Record<string, unknown>): void {
+    const details = params.exceptionDetails as Record<string, unknown>;
+    if (!details) return;
+
+    const exception = details.exception as Record<string, unknown> | undefined;
+    const trace = details.stackTrace as Record<string, unknown> | undefined;
+    const callFrames = trace?.callFrames as
+      | Array<Record<string, unknown>>
+      | undefined;
+
+    // Detect unhandled promise rejections from the exception text/description
+    const text = (details.text as string) ?? "Unknown error";
+    const desc = exception?.description as string | undefined;
+    const isUnhandledRejection =
+      text.includes("Unhandled") ||
+      text.includes("promise") ||
+      (desc != null && (desc.includes("Unhandled") || desc.includes("promise rejection")));
+
+    const entry: ErrorEntry = {
+      id: ++this.entryCounter,
+      timestamp: new Date().toISOString(),
+      type: isUnhandledRejection ? "unhandled-rejection" : "exception",
+      message: text,
+      description: desc,
+      url: details.url as string | undefined,
+      line: details.lineNumber as number | undefined,
+      column: details.columnNumber as number | undefined,
+      stackTrace: callFrames ? formatCallFrames(callFrames) : undefined,
+    };
+
+    this.errorBuffer.push(entry);
+    if (this.errorBuffer.length > MAX_ERROR_ENTRIES) {
+      this.errorBuffer = this.errorBuffer.slice(-MAX_ERROR_ENTRIES);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function mapConsoleLevel(
+  level: string,
+): ConsoleEntry["level"] {
+  switch (level) {
+    case "warning":
+    case "warn":
+      return "warning";
+    case "error":
+      return "error";
+    case "info":
+      return "info";
+    case "debug":
+      return "debug";
+    case "verbose":
+    case "trace":
+      return "verbose";
+    default:
+      return "log";
+  }
+}
+
+function formatCallFrames(
+  frames: Array<Record<string, unknown>>,
+): string {
+  return frames
+    .slice(0, 10)
+    .map((f) => {
+      const fn = (f.functionName as string) || "(anonymous)";
+      const url = f.url as string;
+      const line = f.lineNumber as number;
+      const col = f.columnNumber as number;
+      return `  at ${fn} (${url}:${line}:${col})`;
+    })
+    .join("\n");
+}
+
+function formatExceptionDetails(
+  details: Record<string, unknown>,
+): string {
+  const text = details.text as string | undefined;
+  const exception = details.exception as Record<string, unknown> | undefined;
+  const desc = exception?.description as string | undefined;
+  return desc || text || "Unknown exception";
+}

--- a/src/main/devtools/tools.ts
+++ b/src/main/devtools/tools.ts
@@ -2,7 +2,8 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { AgentRuntime } from "../agent/runtime";
 import type { TabManager } from "../tabs/tab-manager";
-import { getOrCreateSession } from "./manager";
+import { getOrCreateSession, getSession } from "./manager";
+import type { DevToolsActivityEntry, DevToolsPanelState } from "./types";
 
 function asTextResponse(text: string) {
   return { content: [{ type: "text" as const, text }] };
@@ -14,6 +15,34 @@ const DANGEROUS_DEVTOOLS_ACTIONS = new Set([
   "devtools_set_storage",
 ]);
 
+// State broadcast for the DevTools panel UI
+let stateListener: ((state: DevToolsPanelState) => void) | null = null;
+const activityLog: DevToolsActivityEntry[] = [];
+const MAX_ACTIVITY_ENTRIES = 100;
+let activityCounter = 0;
+
+export function setDevToolsPanelListener(
+  listener: ((state: DevToolsPanelState) => void) | null,
+): void {
+  stateListener = listener;
+}
+
+export function getDevToolsPanelState(tabId: string | null): DevToolsPanelState {
+  const session = tabId ? getSession(tabId) : undefined;
+  return {
+    console: session?.getConsoleLogs() ?? [],
+    network: session?.getNetworkLog() ?? [],
+    errors: session?.getErrors() ?? [],
+    activity: activityLog,
+  };
+}
+
+function broadcastState(tabManager: TabManager): void {
+  if (!stateListener) return;
+  const tabId = tabManager.getActiveTabId();
+  stateListener(getDevToolsPanelState(tabId));
+}
+
 async function withDevToolsAction(
   runtime: AgentRuntime,
   tabManager: TabManager,
@@ -21,6 +50,22 @@ async function withDevToolsAction(
   args: Record<string, unknown>,
   executor: () => Promise<string>,
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  const activityEntry: DevToolsActivityEntry = {
+    id: ++activityCounter,
+    timestamp: new Date().toISOString(),
+    tool: name,
+    args: JSON.stringify(args).slice(0, 200),
+    result: "",
+    durationMs: 0,
+    status: "running",
+  };
+  activityLog.push(activityEntry);
+  if (activityLog.length > MAX_ACTIVITY_ENTRIES) {
+    activityLog.splice(0, activityLog.length - MAX_ACTIVITY_ENTRIES);
+  }
+  broadcastState(tabManager);
+
+  const startTime = Date.now();
   try {
     const result = await runtime.runControlledAction({
       source: "mcp",
@@ -30,11 +75,18 @@ async function withDevToolsAction(
       dangerous: DANGEROUS_DEVTOOLS_ACTIONS.has(name),
       executor,
     });
+    activityEntry.status = "completed";
+    activityEntry.result = result.slice(0, 200);
+    activityEntry.durationMs = Date.now() - startTime;
+    broadcastState(tabManager);
     return asTextResponse(result);
   } catch (error) {
-    return asTextResponse(
-      `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
-    );
+    const message = error instanceof Error ? error.message : "Unknown error";
+    activityEntry.status = "failed";
+    activityEntry.result = message.slice(0, 200);
+    activityEntry.durationMs = Date.now() - startTime;
+    broadcastState(tabManager);
+    return asTextResponse(`Error: ${message}`);
   }
 }
 

--- a/src/main/devtools/tools.ts
+++ b/src/main/devtools/tools.ts
@@ -1,0 +1,514 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { AgentRuntime } from "../agent/runtime";
+import type { TabManager } from "../tabs/tab-manager";
+import { getOrCreateSession } from "./manager";
+
+function asTextResponse(text: string) {
+  return { content: [{ type: "text" as const, text }] };
+}
+
+const DANGEROUS_DEVTOOLS_ACTIONS = new Set([
+  "devtools_execute_js",
+  "devtools_modify_dom",
+  "devtools_set_storage",
+]);
+
+async function withDevToolsAction(
+  runtime: AgentRuntime,
+  tabManager: TabManager,
+  name: string,
+  args: Record<string, unknown>,
+  executor: () => Promise<string>,
+): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+  try {
+    const result = await runtime.runControlledAction({
+      source: "mcp",
+      name,
+      args,
+      tabId: tabManager.getActiveTabId(),
+      dangerous: DANGEROUS_DEVTOOLS_ACTIONS.has(name),
+      executor,
+    });
+    return asTextResponse(result);
+  } catch (error) {
+    return asTextResponse(
+      `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+    );
+  }
+}
+
+export function registerDevTools(
+  server: McpServer,
+  tabManager: TabManager,
+  runtime: AgentRuntime,
+): void {
+  // ---------------------------------------------------------------------------
+  // Console
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_console_logs",
+    {
+      title: "DevTools: Get Console Logs",
+      description:
+        "Get console log entries captured from the active tab. Returns a rolling buffer of recent console.log, console.warn, console.error, etc. calls. Automatically starts capturing on first use.",
+      inputSchema: {
+        level: z
+          .enum(["log", "warning", "error", "info", "debug", "verbose"])
+          .optional()
+          .describe("Filter by log level"),
+        limit: z
+          .number()
+          .optional()
+          .describe("Maximum number of entries to return (default: all)"),
+        search: z
+          .string()
+          .optional()
+          .describe("Filter entries containing this text (case-insensitive)"),
+      },
+    },
+    async ({ level, limit, search }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_console_logs",
+        { level, limit, search },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          await session.ensureConsoleDomain();
+          const entries = session.getConsoleLogs({ level, limit, search });
+          if (entries.length === 0) {
+            return "No console entries captured yet. Console monitoring is now active — new entries will be captured as they occur.";
+          }
+          return JSON.stringify(entries, null, 2);
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_console_clear",
+    {
+      title: "DevTools: Clear Console Logs",
+      description: "Clear the captured console log buffer for the active tab.",
+    },
+    async () => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_console_clear",
+        {},
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const count = session.clearConsoleLogs();
+          return `Cleared ${count} console entries.`;
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Network
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_network_log",
+    {
+      title: "DevTools: Get Network Log",
+      description:
+        "Get captured network requests/responses from the active tab. Returns method, URL, status, timing, headers, and size. Automatically starts capturing on first use.",
+      inputSchema: {
+        url_pattern: z
+          .string()
+          .optional()
+          .describe("Filter by URL pattern (regex or substring match)"),
+        method: z
+          .string()
+          .optional()
+          .describe("Filter by HTTP method (GET, POST, etc.)"),
+        status_min: z
+          .number()
+          .optional()
+          .describe("Minimum HTTP status code (e.g., 400 for errors)"),
+        status_max: z
+          .number()
+          .optional()
+          .describe("Maximum HTTP status code"),
+        limit: z
+          .number()
+          .optional()
+          .describe("Maximum number of entries to return (default: all)"),
+      },
+    },
+    async ({ url_pattern, method, status_min, status_max, limit }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_network_log",
+        { url_pattern, method, status_min, status_max, limit },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          await session.ensureNetworkDomain();
+          const entries = session.getNetworkLog({
+            urlPattern: url_pattern,
+            method,
+            statusRange:
+              status_min != null || status_max != null
+                ? { min: status_min, max: status_max }
+                : undefined,
+            limit,
+          });
+          if (entries.length === 0) {
+            return "No network requests captured yet. Network monitoring is now active — new requests will be captured as they occur.";
+          }
+          return JSON.stringify(entries, null, 2);
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_network_response_body",
+    {
+      title: "DevTools: Get Network Response Body",
+      description:
+        "Get the response body for a specific network request by its request ID. Use vessel_devtools_network_log first to find the request ID.",
+      inputSchema: {
+        request_id: z
+          .string()
+          .describe("The requestId from a network log entry"),
+      },
+    },
+    async ({ request_id }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_network_response_body",
+        { request_id },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const result = await session.getNetworkResponseBody(request_id);
+          if ("error" in result) return `Error: ${result.error}`;
+          if (result.base64Encoded) {
+            return `[Base64-encoded body, ${result.body.length} chars. Likely binary content.]`;
+          }
+          const body = result.body;
+          return body.length > 20000
+            ? body.slice(0, 20000) + `\n... [truncated, total ${body.length} chars]`
+            : body;
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_network_clear",
+    {
+      title: "DevTools: Clear Network Log",
+      description: "Clear the captured network request buffer for the active tab.",
+    },
+    async () => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_network_clear",
+        {},
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const count = session.clearNetworkLog();
+          return `Cleared ${count} network entries.`;
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // DOM
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_query_dom",
+    {
+      title: "DevTools: Query DOM",
+      description:
+        "Query the DOM of the active tab using a CSS selector. Returns matching elements with their attributes, node type, and optionally their HTML content. Limited to 50 results.",
+      inputSchema: {
+        selector: z.string().describe("CSS selector to query"),
+        include_html: z
+          .boolean()
+          .optional()
+          .describe("Include outerHTML of matched elements (default: false)"),
+      },
+    },
+    async ({ selector, include_html }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_query_dom",
+        { selector, include_html },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const nodes = await session.queryDom(selector, {
+            includeHtml: include_html,
+          });
+          if (nodes.length === 0) {
+            return `No elements found matching "${selector}"`;
+          }
+          return JSON.stringify(nodes, null, 2);
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_get_styles",
+    {
+      title: "DevTools: Get Computed Styles",
+      description:
+        "Get computed CSS styles for an element matching a CSS selector. Optionally filter to specific properties.",
+      inputSchema: {
+        selector: z.string().describe("CSS selector for the target element"),
+        properties: z
+          .array(z.string())
+          .optional()
+          .describe(
+            'Specific CSS properties to return (e.g., ["color", "font-size", "display"]). Omit for all properties.',
+          ),
+      },
+    },
+    async ({ selector, properties }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_get_styles",
+        { selector, properties },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const styles = await session.getComputedStyles(selector, properties);
+          if (styles.length === 0) {
+            return `No computed styles found for "${selector}"`;
+          }
+          return JSON.stringify(styles, null, 2);
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_modify_dom",
+    {
+      title: "DevTools: Modify DOM Attribute",
+      description:
+        "Set or remove an HTML attribute on an element matching a CSS selector. This is a dangerous action that modifies the page.",
+      inputSchema: {
+        selector: z.string().describe("CSS selector for the target element"),
+        attribute: z.string().describe("Attribute name to set or remove"),
+        value: z
+          .string()
+          .nullable()
+          .describe("Attribute value to set, or null to remove the attribute"),
+      },
+    },
+    async ({ selector, attribute, value }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_modify_dom",
+        { selector, attribute, value },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          return session.modifyDomAttribute(selector, attribute, value);
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // JavaScript Execution
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_execute_js",
+    {
+      title: "DevTools: Execute JavaScript",
+      description:
+        "Execute a JavaScript expression in the context of the active tab's page via the Runtime.evaluate CDP method. Supports async/await. This is a dangerous action — it can modify page state.",
+      inputSchema: {
+        expression: z
+          .string()
+          .describe("JavaScript expression to evaluate in the page context"),
+      },
+    },
+    async ({ expression }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_execute_js",
+        { expression: expression.slice(0, 200) },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const result = await session.executeJs(expression);
+          const parts = [`[${result.type}] ${result.result}`];
+          if (result.exceptionDetails) {
+            parts.push(`\nException: ${result.exceptionDetails}`);
+          }
+          return parts.join("");
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Storage
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_get_storage",
+    {
+      title: "DevTools: Get Storage",
+      description:
+        "Read browser storage for the active tab's origin. Supports localStorage, sessionStorage, cookies, and IndexedDB database listing.",
+      inputSchema: {
+        type: z
+          .enum(["localStorage", "sessionStorage", "cookie", "indexedDB"])
+          .describe("Storage type to read"),
+      },
+    },
+    async ({ type }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_get_storage",
+        { type },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const data = await session.getStorage(type);
+          const count = Object.keys(data.entries).length;
+          if (count === 0) {
+            return `No ${type} entries found for ${data.origin}`;
+          }
+          return JSON.stringify(data, null, 2);
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_set_storage",
+    {
+      title: "DevTools: Set Storage",
+      description:
+        "Set or remove a key in localStorage or sessionStorage for the active tab. This is a dangerous action that modifies page state.",
+      inputSchema: {
+        type: z
+          .enum(["localStorage", "sessionStorage"])
+          .describe("Storage type to modify"),
+        key: z.string().describe("Storage key"),
+        value: z
+          .string()
+          .nullable()
+          .describe("Value to set, or null to remove the key"),
+      },
+    },
+    async ({ type, key, value }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_set_storage",
+        { type, key, value: value ? value.slice(0, 100) : null },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          return session.setStorage(type, key, value);
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Performance
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_performance",
+    {
+      title: "DevTools: Performance Snapshot",
+      description:
+        "Get a performance snapshot for the active tab including navigation timing, paint metrics, memory usage, and resource loading statistics.",
+    },
+    async () => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_performance",
+        {},
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const snapshot = await session.getPerformanceSnapshot();
+          return JSON.stringify(snapshot, null, 2);
+        },
+      );
+    },
+  );
+
+  // ---------------------------------------------------------------------------
+  // Errors
+  // ---------------------------------------------------------------------------
+
+  server.registerTool(
+    "vessel_devtools_get_errors",
+    {
+      title: "DevTools: Get Errors",
+      description:
+        "Get captured JavaScript errors and unhandled promise rejections from the active tab. Automatically starts capturing on first use.",
+      inputSchema: {
+        type: z
+          .enum(["exception", "unhandled-rejection"])
+          .optional()
+          .describe("Filter by error type"),
+        limit: z
+          .number()
+          .optional()
+          .describe("Maximum number of entries to return (default: all)"),
+      },
+    },
+    async ({ type, limit }) => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_get_errors",
+        { type, limit },
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          await session.ensureErrorCapture();
+          const entries = session.getErrors({ type, limit });
+          if (entries.length === 0) {
+            return "No errors captured yet. Error monitoring is now active — exceptions and unhandled rejections will be captured as they occur.";
+          }
+          return JSON.stringify(entries, null, 2);
+        },
+      );
+    },
+  );
+
+  server.registerTool(
+    "vessel_devtools_clear_errors",
+    {
+      title: "DevTools: Clear Errors",
+      description: "Clear the captured error buffer for the active tab.",
+    },
+    async () => {
+      return withDevToolsAction(
+        runtime,
+        tabManager,
+        "devtools_clear_errors",
+        {},
+        async () => {
+          const session = getOrCreateSession(tabManager);
+          const count = session.clearErrors();
+          return `Cleared ${count} error entries.`;
+        },
+      );
+    },
+  );
+}

--- a/src/main/devtools/types.ts
+++ b/src/main/devtools/types.ts
@@ -88,3 +88,22 @@ export interface ErrorEntry {
   column?: number;
   stackTrace?: string;
 }
+
+export type DevToolsPanelTab = "console" | "network" | "activity";
+
+export interface DevToolsActivityEntry {
+  id: number;
+  timestamp: string;
+  tool: string;
+  args: string;
+  result: string;
+  durationMs: number;
+  status: "running" | "completed" | "failed";
+}
+
+export interface DevToolsPanelState {
+  console: ConsoleEntry[];
+  network: NetworkEntry[];
+  errors: ErrorEntry[];
+  activity: DevToolsActivityEntry[];
+}

--- a/src/main/devtools/types.ts
+++ b/src/main/devtools/types.ts
@@ -1,0 +1,90 @@
+export interface ConsoleEntry {
+  id: number;
+  timestamp: string;
+  level: "log" | "warning" | "error" | "info" | "debug" | "verbose";
+  text: string;
+  url?: string;
+  line?: number;
+  column?: number;
+  stackTrace?: string;
+}
+
+export interface NetworkEntry {
+  id: number;
+  requestId: string;
+  timestamp: string;
+  method: string;
+  url: string;
+  resourceType?: string;
+  status?: number;
+  statusText?: string;
+  requestHeaders?: Record<string, string>;
+  responseHeaders?: Record<string, string>;
+  mimeType?: string;
+  contentLength?: number;
+  timing?: {
+    startTime: number;
+    endTime?: number;
+    durationMs?: number;
+  };
+  error?: string;
+  fromCache?: boolean;
+}
+
+export interface DomNodeInfo {
+  nodeId: number;
+  nodeType: number;
+  nodeName: string;
+  localName: string;
+  attributes: Record<string, string>;
+  childCount: number;
+  innerText?: string;
+  innerHTML?: string;
+  outerHTML?: string;
+}
+
+export interface ComputedStyle {
+  property: string;
+  value: string;
+}
+
+export interface StorageData {
+  type: "localStorage" | "sessionStorage" | "cookie" | "indexedDB";
+  origin: string;
+  entries: Record<string, string>;
+}
+
+export interface PerformanceSnapshot {
+  timestamp: string;
+  pageUrl: string;
+  timing: {
+    navigationStart?: number;
+    domContentLoaded?: number;
+    loadComplete?: number;
+    firstPaint?: number;
+    firstContentfulPaint?: number;
+  };
+  memory?: {
+    jsHeapSizeLimit: number;
+    totalJSHeapSize: number;
+    usedJSHeapSize: number;
+  };
+  resources: {
+    total: number;
+    byType: Record<string, number>;
+    totalTransferSize: number;
+    totalDecodedSize: number;
+  };
+}
+
+export interface ErrorEntry {
+  id: number;
+  timestamp: string;
+  type: "exception" | "unhandled-rejection";
+  message: string;
+  description?: string;
+  url?: string;
+  line?: number;
+  column?: number;
+  stackTrace?: string;
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import {
 } from "./config/settings";
 import { startMcpServer, stopMcpServer } from "./mcp/server";
 import { AgentRuntime } from "./agent/runtime";
+import { setDevToolsPanelListener } from "./devtools/tools";
 import { installAdBlocking } from "./network/ad-blocking";
 import * as bookmarkManager from "./bookmarks/manager";
 import {
@@ -20,7 +21,7 @@ import {
 } from "./health/runtime-health";
 import type { RuntimeHealthIssue, VesselSettings } from "../shared/types";
 
-function rendererUrlFor(view: "chrome" | "sidebar"): string | null {
+function rendererUrlFor(view: "chrome" | "sidebar" | "devtools"): string | null {
   if (!process.env.ELECTRON_RENDERER_URL) return null;
   const url = new URL(process.env.ELECTRON_RENDERER_URL);
   url.searchParams.set("view", view);
@@ -131,9 +132,16 @@ async function bootstrap(): Promise<void> {
     runtime?.onTabStateChanged();
   });
 
-  const { chromeView, sidebarView, tabManager } = windowState;
+  const { chromeView, sidebarView, devtoolsPanelView, tabManager } = windowState;
   runtime = new AgentRuntime(tabManager);
   installAdBlocking(tabManager);
+
+  // Wire devtools panel state updates to the devtools panel renderer view
+  setDevToolsPanelListener((state) => {
+    if (!devtoolsPanelView.webContents.isDestroyed()) {
+      devtoolsPanelView.webContents.send(Channels.DEVTOOLS_PANEL_STATE, state);
+    }
+  });
 
   registerIpcHandlers(windowState, runtime);
 
@@ -184,10 +192,12 @@ async function bootstrap(): Promise<void> {
   // Load renderer
   const chromeUrl = rendererUrlFor("chrome");
   const sidebarUrl = rendererUrlFor("sidebar");
+  const devtoolsUrl = rendererUrlFor("devtools");
 
-  if (chromeUrl && sidebarUrl) {
+  if (chromeUrl && sidebarUrl && devtoolsUrl) {
     chromeView.webContents.loadURL(chromeUrl);
     sidebarView.webContents.loadURL(sidebarUrl);
+    devtoolsPanelView.webContents.loadURL(devtoolsUrl);
   } else {
     const rendererFile = path.join(__dirname, "../renderer/index.html");
     chromeView.webContents.loadFile(rendererFile, {
@@ -195,6 +205,9 @@ async function bootstrap(): Promise<void> {
     });
     sidebarView.webContents.loadFile(rendererFile, {
       query: { view: "sidebar" },
+    });
+    devtoolsPanelView.webContents.loadFile(rendererFile, {
+      query: { view: "devtools" },
     });
   }
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -3,7 +3,7 @@ import { Channels } from "../../shared/channels";
 import { extractContent } from "../content/extractor";
 import { generateReaderHTML } from "../content/reader-mode";
 import { loadSettings, setSetting } from "../config/settings";
-import { layoutViews, type WindowState } from "../window";
+import { layoutViews, MIN_DEVTOOLS_PANEL, MAX_DEVTOOLS_PANEL, type WindowState } from "../window";
 import { getRuntimeHealth } from "../health/runtime-health";
 import type {
   ApprovalMode,
@@ -20,11 +20,12 @@ export function registerIpcHandlers(
   windowState: WindowState,
   runtime: AgentRuntime,
 ): void {
-  const { tabManager, chromeView, sidebarView, mainWindow } = windowState;
+  const { tabManager, chromeView, sidebarView, devtoolsPanelView, mainWindow } = windowState;
 
   const sendToRendererViews = (channel: string, ...args: unknown[]) => {
     chromeView.webContents.send(channel, ...args);
     sidebarView.webContents.send(channel, ...args);
+    devtoolsPanelView.webContents.send(channel, ...args);
   };
 
   runtime.setUpdateListener((state: AgentRuntimeState) => {
@@ -321,6 +322,21 @@ export function registerIpcHandlers(
     } catch {
       // Silently ignore errors from auto-highlight
     }
+  });
+
+  // --- DevTools panel ---
+
+  ipcMain.handle(Channels.DEVTOOLS_PANEL_TOGGLE, () => {
+    windowState.uiState.devtoolsPanelOpen = !windowState.uiState.devtoolsPanelOpen;
+    layoutViews(windowState);
+    return { open: windowState.uiState.devtoolsPanelOpen };
+  });
+
+  ipcMain.handle("devtools-panel:resize", (_, height: number) => {
+    const clamped = Math.max(MIN_DEVTOOLS_PANEL, Math.min(MAX_DEVTOOLS_PANEL, Math.round(height)));
+    windowState.uiState.devtoolsPanelHeight = clamped;
+    layoutViews(windowState);
+    return clamped;
   });
 
   // --- Window controls ---

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -7,6 +7,7 @@ import { layoutViews, MIN_DEVTOOLS_PANEL, MAX_DEVTOOLS_PANEL, type WindowState }
 import { getRuntimeHealth } from "../health/runtime-health";
 import { createProvider, fetchProviderModels } from "../ai/provider";
 import type { AIProvider } from "../ai/provider";
+import { handleAIQuery } from "../ai/commands";
 import type {
   AIMessage,
   ApprovalMode,
@@ -90,11 +91,15 @@ export function registerIpcHandlers(
 
     try {
       activeChatProvider = createProvider(chatConfig);
-      await activeChatProvider.streamQuery(
-        "You are a helpful AI assistant integrated into the Vessel browser. Be concise and helpful.",
+      const activeTab = tabManager.getActiveTab();
+      await handleAIQuery(
         query,
+        activeChatProvider,
+        activeTab?.view.webContents,
         (chunk) => sendToRendererViews(Channels.AI_STREAM_CHUNK, chunk),
         () => sendToRendererViews(Channels.AI_STREAM_END),
+        tabManager,
+        runtime,
         history,
       );
     } catch (err: unknown) {

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -95,11 +95,21 @@ export function registerIpcHandlers(
     const activeTab = tabManager.getActiveTab();
     if (!activeTab) return;
 
-    const content = await extractContent(activeTab.view.webContents);
-    const html = generateReaderHTML(content);
-    activeTab.view.webContents.loadURL(
-      `data:text/html;charset=utf-8,${encodeURIComponent(html)}`,
-    );
+    if (activeTab.state.isReaderMode) {
+      const originalUrl = activeTab.readerOriginalUrl;
+      activeTab.setReaderMode(false);
+      if (originalUrl) {
+        activeTab.view.webContents.loadURL(originalUrl);
+      }
+    } else {
+      const originalUrl = activeTab.state.url;
+      const content = await extractContent(activeTab.view.webContents);
+      const html = generateReaderHTML(content);
+      activeTab.setReaderMode(true, originalUrl);
+      activeTab.view.webContents.loadURL(
+        `data:text/html;charset=utf-8,${encodeURIComponent(html)}`,
+      );
+    }
   });
 
   // --- UI handlers ---

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -5,7 +5,10 @@ import { generateReaderHTML } from "../content/reader-mode";
 import { loadSettings, setSetting } from "../config/settings";
 import { layoutViews, MIN_DEVTOOLS_PANEL, MAX_DEVTOOLS_PANEL, type WindowState } from "../window";
 import { getRuntimeHealth } from "../health/runtime-health";
+import { createProvider } from "../ai/provider";
+import type { AIProvider } from "../ai/provider";
 import type {
+  AIMessage,
   ApprovalMode,
   AgentRuntimeState,
   SessionSnapshot,
@@ -15,6 +18,8 @@ import * as bookmarkManager from "../bookmarks/manager";
 import * as highlightsManager from "../highlights/manager";
 import { highlightOnPage } from "../highlights/inject";
 import { startMcpServer, stopMcpServer } from "../mcp/server";
+
+let activeChatProvider: AIProvider | null = null;
 
 export function registerIpcHandlers(
   windowState: WindowState,
@@ -68,20 +73,42 @@ export function registerIpcHandlers(
 
   // --- AI handlers ---
 
-  ipcMain.handle(Channels.AI_QUERY, async (_, query: string) => {
+  ipcMain.handle(Channels.AI_QUERY, async (_, query: string, history?: AIMessage[]) => {
+    const settings = loadSettings();
+    const chatConfig = settings.chatProvider;
+
     sendToRendererViews(Channels.AI_STREAM_START, query);
-    sendToRendererViews(
-      Channels.AI_STREAM_CHUNK,
-      [
-        "Vessel does not run a locally configured model.",
-        "Control it through an external agent harness such as Hermes Agent or OpenClaw.",
-        "Use the sidebar here for runtime visibility, approvals, checkpoints, and bookmarks.",
-      ].join("\n\n"),
-    );
-    sendToRendererViews(Channels.AI_STREAM_END);
+
+    if (!chatConfig) {
+      sendToRendererViews(
+        Channels.AI_STREAM_CHUNK,
+        "Chat provider not configured. Open Settings (Ctrl+,) to choose a provider.",
+      );
+      sendToRendererViews(Channels.AI_STREAM_END);
+      return;
+    }
+
+    try {
+      activeChatProvider = createProvider(chatConfig);
+      await activeChatProvider.streamQuery(
+        "You are a helpful AI assistant integrated into the Vessel browser. Be concise and helpful.",
+        query,
+        (chunk) => sendToRendererViews(Channels.AI_STREAM_CHUNK, chunk),
+        () => sendToRendererViews(Channels.AI_STREAM_END),
+        history,
+      );
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      sendToRendererViews(Channels.AI_STREAM_CHUNK, `\n[Error: ${msg}]`);
+      sendToRendererViews(Channels.AI_STREAM_END);
+    } finally {
+      activeChatProvider = null;
+    }
   });
 
-  ipcMain.handle(Channels.AI_CANCEL, () => undefined);
+  ipcMain.handle(Channels.AI_CANCEL, () => {
+    activeChatProvider?.cancel();
+  });
 
   // --- Content handlers ---
 

--- a/src/main/ipc/handlers.ts
+++ b/src/main/ipc/handlers.ts
@@ -5,7 +5,7 @@ import { generateReaderHTML } from "../content/reader-mode";
 import { loadSettings, setSetting } from "../config/settings";
 import { layoutViews, MIN_DEVTOOLS_PANEL, MAX_DEVTOOLS_PANEL, type WindowState } from "../window";
 import { getRuntimeHealth } from "../health/runtime-health";
-import { createProvider } from "../ai/provider";
+import { createProvider, fetchProviderModels } from "../ai/provider";
 import type { AIProvider } from "../ai/provider";
 import type {
   AIMessage,
@@ -108,6 +108,15 @@ export function registerIpcHandlers(
 
   ipcMain.handle(Channels.AI_CANCEL, () => {
     activeChatProvider?.cancel();
+  });
+
+  ipcMain.handle(Channels.AI_FETCH_MODELS, async (_, config: unknown) => {
+    try {
+      const models = await fetchProviderModels(config as Parameters<typeof fetchProviderModels>[0]);
+      return { ok: true, models };
+    } catch (err: unknown) {
+      return { ok: false, models: [], error: err instanceof Error ? err.message : "Unknown error" };
+    }
   });
 
   // --- Content handlers ---

--- a/src/main/mcp/server.ts
+++ b/src/main/mcp/server.ts
@@ -38,6 +38,7 @@ import {
   writeMemoryNote,
 } from "../memory/obsidian";
 import { setMcpHealth } from "../health/runtime-health";
+import { registerDevTools } from "../devtools/tools";
 
 let httpServer: http.Server | null = null;
 
@@ -3911,6 +3912,7 @@ function createMcpServer(
     version: "0.1.0",
   });
   registerTools(server, tabManager, runtime);
+  registerDevTools(server, tabManager, runtime);
   return server;
 }
 

--- a/src/main/tabs/tab-manager.ts
+++ b/src/main/tabs/tab-manager.ts
@@ -4,6 +4,7 @@ import { randomUUID } from "crypto";
 import type { HighlightColor, SessionSnapshot, TabState } from "../../shared/types";
 import * as highlightsManager from "../highlights/manager";
 import { highlightOnPage } from "../highlights/inject";
+import { destroySession, destroyAllSessions } from "../devtools/manager";
 
 export type HighlightCaptureResult = {
   success: boolean;
@@ -79,6 +80,7 @@ export class TabManager {
     const tab = this.tabs.get(id);
     if (!tab) return;
 
+    destroySession(id);
     this.window.contentView.removeChildView(tab.view);
     tab.destroy();
     this.tabs.delete(id);
@@ -201,6 +203,7 @@ export class TabManager {
   }
 
   private destroyAllTabs(): void {
+    destroyAllSessions();
     for (const id of this.order) {
       const tab = this.tabs.get(id);
       if (!tab) continue;

--- a/src/main/tabs/tab.ts
+++ b/src/main/tabs/tab.ts
@@ -33,6 +33,7 @@ export class Tab {
     color: HighlightColor,
   ) => void;
   private _highlightModeActive = false;
+  private _readerOriginalUrl: string | null = null;
 
   // Fully custom URL history — we never rely on Chromium's native back/forward
   // because loadURL() calls (used for anchor clicks, form GETs, etc.) pollute
@@ -349,6 +350,20 @@ export class Tab {
 
   get highlightModeActive(): boolean {
     return this._highlightModeActive;
+  }
+
+  get readerOriginalUrl(): string | null {
+    return this._readerOriginalUrl;
+  }
+
+  setReaderMode(enabled: boolean, originalUrl?: string): void {
+    this._state.isReaderMode = enabled;
+    if (enabled && originalUrl) {
+      this._readerOriginalUrl = originalUrl;
+    } else if (!enabled) {
+      this._readerOriginalUrl = null;
+    }
+    this.onChange();
   }
 
   setHighlightMode(enabled: boolean): void {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -7,10 +7,15 @@ import type { UIState } from "../shared/types";
 
 const CHROME_HEIGHT = 110; // title(32) + tabs(36+1border) + address(40+1border)
 
+const DEFAULT_DEVTOOLS_PANEL_HEIGHT = 250;
+const MIN_DEVTOOLS_PANEL = 120;
+const MAX_DEVTOOLS_PANEL = 600;
+
 export interface WindowState {
   mainWindow: BaseWindow;
   chromeView: WebContentsView;
   sidebarView: WebContentsView;
+  devtoolsPanelView: WebContentsView;
   tabManager: TabManager;
   uiState: UIState;
 }
@@ -62,12 +67,26 @@ export function createMainWindow(
   sidebarView.setBackgroundColor("#00000000");
   mainWindow.contentView.addChildView(sidebarView);
 
+  const devtoolsPanelView = new WebContentsView({
+    webPreferences: {
+      preload: path.join(__dirname, "../preload/index.js"),
+      sandbox: true,
+      contextIsolation: true,
+      nodeIntegration: false,
+    },
+  });
+
+  devtoolsPanelView.setBackgroundColor("#00000000");
+  mainWindow.contentView.addChildView(devtoolsPanelView);
+
   const settings = loadSettings();
   const uiState: UIState = {
     sidebarOpen: false,
     sidebarWidth: settings.sidebarWidth,
     focusMode: false,
     settingsOpen: false,
+    devtoolsPanelOpen: false,
+    devtoolsPanelHeight: DEFAULT_DEVTOOLS_PANEL_HEIGHT,
   };
 
   const tabManager = new TabManager(mainWindow, onTabStateChange);
@@ -76,6 +95,7 @@ export function createMainWindow(
     mainWindow,
     chromeView,
     sidebarView,
+    devtoolsPanelView,
     tabManager,
     uiState,
   };
@@ -89,10 +109,11 @@ export function createMainWindow(
 }
 
 export function layoutViews(state: WindowState): void {
-  const { mainWindow, chromeView, sidebarView, tabManager, uiState } = state;
+  const { mainWindow, chromeView, sidebarView, devtoolsPanelView, tabManager, uiState } = state;
   const [width, height] = mainWindow.getContentSize();
   const chromeHeight = uiState.focusMode ? 0 : CHROME_HEIGHT;
   const sidebarWidth = uiState.sidebarOpen ? uiState.sidebarWidth : 0;
+  const devtoolsHeight = uiState.devtoolsPanelOpen ? uiState.devtoolsPanelHeight : 0;
   const chromeNeedsFullHeight = uiState.settingsOpen;
 
   if (chromeNeedsFullHeight) {
@@ -112,20 +133,37 @@ export function layoutViews(state: WindowState): void {
     sidebarView.setBounds({ x: width, y: 0, width: 0, height: 0 });
   }
 
-  // Chrome always on top
+  // DevTools panel: bottom of content area, left of sidebar
+  const contentWidth = width - sidebarWidth;
+  if (uiState.devtoolsPanelOpen) {
+    devtoolsPanelView.setBounds({
+      x: 0,
+      y: height - devtoolsHeight,
+      width: contentWidth,
+      height: devtoolsHeight,
+    });
+  } else {
+    devtoolsPanelView.setBounds({ x: 0, y: height, width: 0, height: 0 });
+  }
+
+  // Chrome, sidebar, and devtools panel always on top of tab content
   mainWindow.contentView.removeChildView(chromeView);
   mainWindow.contentView.addChildView(chromeView);
   mainWindow.contentView.removeChildView(sidebarView);
   mainWindow.contentView.addChildView(sidebarView);
+  mainWindow.contentView.removeChildView(devtoolsPanelView);
+  mainWindow.contentView.addChildView(devtoolsPanelView);
 
-  // Active tab content: below chrome, left of sidebar
+  // Active tab content: below chrome, left of sidebar, above devtools panel
   const activeTab = tabManager.getActiveTab();
   if (activeTab) {
     activeTab.view.setBounds({
       x: 0,
       y: chromeHeight,
-      width: width - sidebarWidth,
-      height: height - chromeHeight,
+      width: contentWidth,
+      height: height - chromeHeight - devtoolsHeight,
     });
   }
 }
+
+export { MIN_DEVTOOLS_PANEL, MAX_DEVTOOLS_PANEL };

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3,6 +3,7 @@ import { Channels } from "../shared/channels";
 import type {
   AgentCheckpoint,
   AgentRuntimeState,
+  AIMessage,
   ApprovalMode,
   Bookmark,
   BookmarkFolder,
@@ -33,7 +34,7 @@ const api = {
     },
   },
   ai: {
-    query: (prompt: string) => ipcRenderer.invoke(Channels.AI_QUERY, prompt),
+    query: (prompt: string, history?: AIMessage[]) => ipcRenderer.invoke(Channels.AI_QUERY, prompt, history),
     onStreamStart: (cb: (prompt: string) => void): (() => void) => {
       const handler = (_: any, prompt: string) => cb(prompt);
       ipcRenderer.on(Channels.AI_STREAM_START, handler);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,6 +53,8 @@ const api = {
       return () => ipcRenderer.removeListener(Channels.AI_STREAM_END, handler);
     },
     cancel: () => ipcRenderer.invoke(Channels.AI_CANCEL),
+    fetchModels: (config: ProviderConfig): Promise<{ ok: boolean; models: string[]; error?: string }> =>
+      ipcRenderer.invoke(Channels.AI_FETCH_MODELS, config),
     getRuntime: (): Promise<AgentRuntimeState> =>
       ipcRenderer.invoke(Channels.AGENT_RUNTIME_GET),
     onRuntimeUpdate: (cb: (state: AgentRuntimeState) => void): (() => void) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -157,6 +157,20 @@ const api = {
         ipcRenderer.removeListener(Channels.BOOKMARKS_UPDATE, handler);
     },
   },
+  devtoolsPanel: {
+    toggle: (): Promise<{ open: boolean }> =>
+      ipcRenderer.invoke(Channels.DEVTOOLS_PANEL_TOGGLE),
+    resize: (height: number) =>
+      ipcRenderer.invoke("devtools-panel:resize", height),
+    onStateUpdate: (
+      cb: (state: any) => void,
+    ): (() => void) => {
+      const handler = (_: any, state: any) => cb(state);
+      ipcRenderer.on(Channels.DEVTOOLS_PANEL_STATE, handler);
+      return () =>
+        ipcRenderer.removeListener(Channels.DEVTOOLS_PANEL_STATE, handler);
+    },
+  },
   window: {
     minimize: () => ipcRenderer.invoke(Channels.WINDOW_MINIMIZE),
     maximize: () => ipcRenderer.invoke(Channels.WINDOW_MAXIMIZE),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import HighlightNotifications from "./components/chrome/HighlightNotifications";
 import AgentTranscriptDock from "./components/chrome/AgentTranscriptDock";
 import CommandBar from "./components/ai/CommandBar";
 import Sidebar from "./components/ai/Sidebar";
+import DevToolsPanel from "./components/devtools/DevToolsPanel";
 import Settings from "./components/shared/Settings";
 import { useUI } from "./stores/ui";
 import { useTabs } from "./stores/tabs";
@@ -83,6 +84,9 @@ const App: Component = () => {
       },
       openSettings,
       captureHighlight,
+      toggleDevTools: () => {
+        window.vessel.devtoolsPanel.toggle();
+      },
     });
 
     // Listen for Ctrl+H captures triggered from the page view
@@ -98,6 +102,10 @@ const App: Component = () => {
 
   if (view === "sidebar") {
     return <Sidebar forceOpen />;
+  }
+
+  if (view === "devtools") {
+    return <DevToolsPanel />;
   }
 
   return (

--- a/src/renderer/src/components/ai/Sidebar.tsx
+++ b/src/renderer/src/components/ai/Sidebar.tsx
@@ -133,6 +133,8 @@ const Sidebar: Component<{ forceOpen?: boolean }> = (props) => {
     hasFirstChunk,
     streamStartedAt,
     clearHistory,
+    query,
+    cancel,
   } = useAI();
   const {
     runtimeState,
@@ -160,7 +162,15 @@ const Sidebar: Component<{ forceOpen?: boolean }> = (props) => {
     removeFolder,
     renameFolder,
   } = useBookmarks();
-  const [sidebarTab, setSidebarTab] = createSignal<"supervisor" | "bookmarks" | "checkpoints">("supervisor");
+  const [sidebarTab, setSidebarTab] = createSignal<"supervisor" | "bookmarks" | "checkpoints" | "chat">("supervisor");
+  const [chatInput, setChatInput] = createSignal("");
+
+  const handleChatSend = async () => {
+    const prompt = chatInput().trim();
+    if (!prompt || isStreaming()) return;
+    setChatInput("");
+    await query(prompt);
+  };
   const [checkpointName, setCheckpointName] = createSignal("");
   const [bookmarkNote, setBookmarkNote] = createSignal("");
   const [bookmarkSaveExpanded, setBookmarkSaveExpanded] = createSignal(false);
@@ -505,6 +515,15 @@ const Sidebar: Component<{ forceOpen?: boolean }> = (props) => {
             onClick={() => setSidebarTab("checkpoints")}
           >
             Checkpoints
+          </button>
+          <button
+            class="sidebar-tab"
+            classList={{ active: sidebarTab() === "chat" }}
+            role="tab"
+            aria-selected={sidebarTab() === "chat"}
+            onClick={() => setSidebarTab("chat")}
+          >
+            Chat
           </button>
         </div>
 
@@ -1005,68 +1024,103 @@ const Sidebar: Component<{ forceOpen?: boolean }> = (props) => {
           </section>
           </Show>
 
-          <For each={messages()}>
-            {(msg) => (
-              <div class={`message message-${msg.role}`}>
-                <MarkdownMessage content={msg.content} />
-              </div>
-            )}
-          </For>
+          <Show when={sidebarTab() === "chat"}>
+            <For each={messages()}>
+              {(msg) => (
+                <div class={`message message-${msg.role}`}>
+                  <MarkdownMessage content={msg.content} />
+                </div>
+              )}
+            </For>
 
-          <Show when={isStreaming()}>
-            <div class="message message-assistant">
-              <div class="message-content">
-                <Show
-                  when={hasFirstChunk()}
-                  fallback={
-                    <div class="thinking-state">
-                      <div class="thinking-orb" aria-hidden="true">
-                        <span />
-                        <span />
-                        <span />
+            <Show when={isStreaming()}>
+              <div class="message message-assistant">
+                <div class="message-content">
+                  <Show
+                    when={hasFirstChunk()}
+                    fallback={
+                      <div class="thinking-state">
+                        <div class="thinking-orb" aria-hidden="true">
+                          <span />
+                          <span />
+                          <span />
+                        </div>
+                        <div class="thinking-copy">
+                          <div class="thinking-title">Thinking</div>
+                        </div>
                       </div>
-                      <div class="thinking-copy">
-                        <div class="thinking-title">Thinking</div>
+                    }
+                  >
+                    <div>
+                      <MarkdownMessage content={streamingText()} />
+                      <div class="streaming-status">
+                        <span class="streaming-pulse" aria-hidden="true" />
+                        <span>Generating</span>
+                        <Show when={elapsedSeconds() > 0}>
+                          <span>{` • ${elapsedSeconds()}s`}</span>
+                        </Show>
                       </div>
                     </div>
-                  }
-                >
-                  <div>
-                    <MarkdownMessage content={streamingText()} />
-                    <div class="streaming-status">
-                      <span class="streaming-pulse" aria-hidden="true" />
-                      <span>Generating</span>
-                      <Show when={elapsedSeconds() > 0}>
-                        <span>{` • ${elapsedSeconds()}s`}</span>
-                      </Show>
-                    </div>
-                  </div>
-                </Show>
+                  </Show>
+                </div>
               </div>
-            </div>
-          </Show>
+            </Show>
 
-          <Show when={messages().length === 0 && !isStreaming()}>
-            <div class="sidebar-empty">
-              <svg class="sidebar-empty-icon" width="48" height="48" viewBox="0 0 48 48" aria-hidden="true">
-                <circle cx="24" cy="24" r="20" fill="none" stroke="var(--border-visible)" stroke-width="1.5" />
-                <circle cx="24" cy="24" r="12" fill="none" stroke="var(--accent-primary)" stroke-width="1" opacity="0.3" />
-                <circle cx="24" cy="24" r="4" fill="none" stroke="var(--accent-primary)" stroke-width="1.5" opacity="0.6" />
-                <line x1="24" y1="4" x2="24" y2="12" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
-                <line x1="24" y1="36" x2="24" y2="44" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
-                <line x1="4" y1="24" x2="12" y2="24" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
-                <line x1="36" y1="24" x2="44" y2="24" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
-              </svg>
-              <p class="sidebar-empty-title">Vessel is ready</p>
-              <p class="sidebar-empty-hint">
-                External harnesses drive this browser. Use the tabs above to
-                watch runtime state, approvals, checkpoints, and bookmarks.
-              </p>
-            </div>
+            <Show when={messages().length === 0 && !isStreaming()}>
+              <div class="sidebar-empty">
+                <svg class="sidebar-empty-icon" width="48" height="48" viewBox="0 0 48 48" aria-hidden="true">
+                  <circle cx="24" cy="24" r="20" fill="none" stroke="var(--border-visible)" stroke-width="1.5" />
+                  <circle cx="24" cy="24" r="12" fill="none" stroke="var(--accent-primary)" stroke-width="1" opacity="0.3" />
+                  <circle cx="24" cy="24" r="4" fill="none" stroke="var(--accent-primary)" stroke-width="1.5" opacity="0.6" />
+                  <line x1="24" y1="4" x2="24" y2="12" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
+                  <line x1="24" y1="36" x2="24" y2="44" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
+                  <line x1="4" y1="24" x2="12" y2="24" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
+                  <line x1="36" y1="24" x2="44" y2="24" stroke="var(--border-visible)" stroke-width="1" stroke-linecap="round" />
+                </svg>
+                <p class="sidebar-empty-title">Your move.</p>
+                <p class="sidebar-empty-hint">
+                  Configure a provider in Settings (Ctrl+,) then ask anything about the current page or beyond.
+                </p>
+              </div>
+            </Show>
           </Show>
 
           <div ref={messagesEndRef} />
         </div>
+
+        <Show when={sidebarTab() === "chat"}>
+          <div class="sidebar-input-area">
+            <textarea
+              class="sidebar-input"
+              rows={2}
+              placeholder="Ask anything..."
+              value={chatInput()}
+              onInput={(e) => setChatInput(e.currentTarget.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  void handleChatSend();
+                }
+              }}
+            />
+            <Show
+              when={isStreaming()}
+              fallback={
+                <button
+                  class="sidebar-send"
+                  disabled={!chatInput().trim()}
+                  onClick={() => void handleChatSend()}
+                >
+                  Send
+                </button>
+              }
+            >
+              <button class="sidebar-cancel" onClick={() => cancel()}>
+                Stop
+              </button>
+            </Show>
+          </div>
+        </Show>
       </div>
     </Show>
   );

--- a/src/renderer/src/components/ai/ai.css
+++ b/src/renderer/src/components/ai/ai.css
@@ -294,17 +294,20 @@
 /* Sidebar section tabs */
 .sidebar-tabs {
     display: flex;
-    padding: 0 14px;
+    padding: 0 10px;
     gap: 2px;
     border-bottom: 1px solid var(--border-subtle);
     flex-shrink: 0;
     background: var(--bg-secondary);
+    overflow: hidden;
 }
 
 .sidebar-tab {
     position: relative;
-    padding: 9px 14px 10px;
+    padding: 9px 10px 10px;
     font-size: 11.5px;
+    flex-shrink: 1;
+    min-width: 0;
     font-weight: 500;
     letter-spacing: 0.01em;
     color: var(--text-muted);

--- a/src/renderer/src/components/ai/ai.css
+++ b/src/renderer/src/components/ai/ai.css
@@ -212,7 +212,7 @@
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     gap: 12px;
-    padding: 14px 16px;
+    padding: 26px 16px 14px;
     border-bottom: 1px solid var(--border-subtle);
     flex-shrink: 0;
 }

--- a/src/renderer/src/components/chrome/AddressBar.tsx
+++ b/src/renderer/src/components/chrome/AddressBar.tsx
@@ -18,7 +18,7 @@ import "./chrome.css";
 const AddressBar: Component = () => {
   const { activeTab, navigate, goBack, goForward, reload } = useTabs();
   const { runtimeState } = useRuntime();
-  const { toggleSidebar, openSettings } = useUI();
+  const { toggleSidebar, openSettings, toggleDevTools, devtoolsPanelOpen } = useUI();
   const [inputValue, setInputValue] = createSignal("");
   const [now, setNow] = createSignal(Date.now());
   let inputRef: HTMLInputElement | undefined;
@@ -152,6 +152,7 @@ const AddressBar: Component = () => {
       <div class="toolbar-actions">
         <button
           class="nav-btn"
+          classList={{ active: !!activeTab()?.isReaderMode }}
           onClick={() => window.vessel.content.toggleReader()}
           data-tooltip="Reader Mode"
         >
@@ -189,6 +190,40 @@ const AddressBar: Component = () => {
               y2="9"
               stroke="currentColor"
               stroke-width="1"
+            />
+          </svg>
+        </button>
+        <button
+          class="nav-btn"
+          classList={{ active: devtoolsPanelOpen() }}
+          onClick={toggleDevTools}
+          data-tooltip="Dev Tools"
+        >
+          <svg width="14" height="14" viewBox="0 0 14 14">
+            <polyline
+              points="3,5 1,7 3,9"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <polyline
+              points="11,5 13,7 11,9"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <line
+              x1="8.5"
+              y1="2"
+              x2="5.5"
+              y2="12"
+              stroke="currentColor"
+              stroke-width="1.2"
+              stroke-linecap="round"
             />
           </svg>
         </button>

--- a/src/renderer/src/components/chrome/chrome.css
+++ b/src/renderer/src/components/chrome/chrome.css
@@ -330,6 +330,11 @@
     cursor: default;
 }
 
+.nav-btn.active {
+    color: var(--accent-primary);
+    background: rgba(196, 160, 90, 0.12);
+}
+
 .nav-btn.ai-btn {
     color: var(--accent-primary);
 }

--- a/src/renderer/src/components/devtools/DevToolsPanel.tsx
+++ b/src/renderer/src/components/devtools/DevToolsPanel.tsx
@@ -55,6 +55,7 @@ interface PanelState {
 }
 
 type PanelTab = "console" | "network" | "activity";
+type DateMode = "today" | "custom";
 
 function formatTime(iso: string): string {
   try {
@@ -94,6 +95,28 @@ function shortenSource(url?: string, line?: number): string {
   } catch {
     return url;
   }
+}
+
+function todayDateString(): string {
+  return new Date().toISOString().split("T")[0];
+}
+
+function filterByDate<T extends { timestamp: string }>(
+  entries: T[],
+  mode: DateMode,
+  dateFrom: string,
+  dateTo: string,
+): T[] {
+  if (mode === "today") {
+    const today = new Date().toDateString();
+    return entries.filter((e) => new Date(e.timestamp).toDateString() === today);
+  }
+  const from = dateFrom ? new Date(dateFrom).getTime() : 0;
+  const to = dateTo ? new Date(dateTo + "T23:59:59.999").getTime() : Infinity;
+  return entries.filter((e) => {
+    const t = new Date(e.timestamp).getTime();
+    return t >= from && t <= to;
+  });
 }
 
 const ConsoleView: Component<{ entries: ConsoleEntry[] }> = (props) => {
@@ -282,6 +305,18 @@ const DevToolsPanel: Component = () => {
     activity: [],
   });
 
+  // Export state
+  const [showExport, setShowExport] = createSignal(false);
+  const [exportConsole, setExportConsole] = createSignal(true);
+  const [exportNetwork, setExportNetwork] = createSignal(true);
+  const [exportActivity, setExportActivity] = createSignal(true);
+  const [dateMode, setDateMode] = createSignal<DateMode>("today");
+  const [dateFrom, setDateFrom] = createSignal(todayDateString());
+  const [dateTo, setDateTo] = createSignal(todayDateString());
+
+  let exportBtnRef: HTMLButtonElement | undefined;
+  let exportDropdownRef: HTMLDivElement | undefined;
+
   createEffect(() => {
     const cleanup = window.vessel.devtoolsPanel.onStateUpdate(
       (newState: PanelState) => {
@@ -289,6 +324,24 @@ const DevToolsPanel: Component = () => {
       },
     );
     onCleanup(cleanup);
+  });
+
+  // Close export dropdown on outside click
+  createEffect(() => {
+    if (!showExport()) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (
+        exportDropdownRef &&
+        !exportDropdownRef.contains(target) &&
+        exportBtnRef &&
+        !exportBtnRef.contains(target)
+      ) {
+        setShowExport(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    onCleanup(() => document.removeEventListener("mousedown", handler));
   });
 
   const errorCount = () => state().errors.length;
@@ -299,6 +352,44 @@ const DevToolsPanel: Component = () => {
   const close = () => {
     window.vessel.devtoolsPanel.toggle();
   };
+
+  const handleExport = () => {
+    const mode = dateMode();
+    const from = dateFrom();
+    const to = dateTo();
+
+    const data: Record<string, unknown> = {
+      exportedAt: new Date().toISOString(),
+      dateRange:
+        mode === "today"
+          ? "today"
+          : { from, to },
+    };
+
+    if (exportConsole()) {
+      data.console = filterByDate(state().console, mode, from, to);
+    }
+    if (exportNetwork()) {
+      data.network = filterByDate(state().network, mode, from, to);
+    }
+    if (exportActivity()) {
+      data.activity = filterByDate(state().activity, mode, from, to);
+    }
+
+    const json = JSON.stringify(data, null, 2);
+    const blob = new Blob([json], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    const date = new Date().toISOString().split("T")[0];
+    anchor.href = url;
+    anchor.download = `vessel-devtools-${date}.json`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    setShowExport(false);
+  };
+
+  const noneSelected = () =>
+    !exportConsole() && !exportNetwork() && !exportActivity();
 
   return (
     <div class="devtools-panel">
@@ -331,6 +422,96 @@ const DevToolsPanel: Component = () => {
           </Show>
         </button>
         <div class="devtools-tab-spacer" />
+        <div class="devtools-export-wrap">
+          <button
+            ref={exportBtnRef}
+            class={`devtools-close-btn ${showExport() ? "active" : ""}`}
+            onClick={() => setShowExport((v) => !v)}
+            title="Export Logs"
+          >
+            <svg width="13" height="13" viewBox="0 0 13 13" fill="none" style="vertical-align: middle;">
+              <path d="M6.5 1v7M3.5 5l3 3 3-3" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"/>
+              <path d="M1 9.5v1A1.5 1.5 0 0 0 2.5 12h8A1.5 1.5 0 0 0 12 10.5v-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+            </svg>
+          </button>
+          <Show when={showExport()}>
+            <div class="devtools-export-dropdown" ref={exportDropdownRef}>
+              <div class="export-section">
+                <div class="export-section-label">Log Types</div>
+                <label class="export-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={exportConsole()}
+                    onChange={(e) => setExportConsole(e.currentTarget.checked)}
+                  />
+                  Console
+                </label>
+                <label class="export-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={exportNetwork()}
+                    onChange={(e) => setExportNetwork(e.currentTarget.checked)}
+                  />
+                  Network
+                </label>
+                <label class="export-checkbox">
+                  <input
+                    type="checkbox"
+                    checked={exportActivity()}
+                    onChange={(e) => setExportActivity(e.currentTarget.checked)}
+                  />
+                  Activity
+                </label>
+              </div>
+              <div class="export-section">
+                <div class="export-section-label">Date Range</div>
+                <div class="export-date-btns">
+                  <button
+                    class={`export-date-btn ${dateMode() === "today" ? "active" : ""}`}
+                    onClick={() => setDateMode("today")}
+                  >
+                    Today
+                  </button>
+                  <button
+                    class={`export-date-btn ${dateMode() === "custom" ? "active" : ""}`}
+                    onClick={() => setDateMode("custom")}
+                  >
+                    Custom
+                  </button>
+                </div>
+                <Show when={dateMode() === "custom"}>
+                  <div class="export-date-inputs">
+                    <div class="export-date-row">
+                      <span class="export-date-label">From</span>
+                      <input
+                        class="export-date-input"
+                        type="date"
+                        value={dateFrom()}
+                        onInput={(e) => setDateFrom(e.currentTarget.value)}
+                      />
+                    </div>
+                    <div class="export-date-row">
+                      <span class="export-date-label">To</span>
+                      <input
+                        class="export-date-input"
+                        type="date"
+                        value={dateTo()}
+                        onInput={(e) => setDateTo(e.currentTarget.value)}
+                      />
+                    </div>
+                  </div>
+                </Show>
+              </div>
+              <button
+                class="export-submit"
+                onClick={handleExport}
+                disabled={noneSelected()}
+              >
+                Export JSON
+              </button>
+            </div>
+          </Show>
+        </div>
         <button class="devtools-close-btn" onClick={close} title="Close DevTools">
           ×
         </button>

--- a/src/renderer/src/components/devtools/DevToolsPanel.tsx
+++ b/src/renderer/src/components/devtools/DevToolsPanel.tsx
@@ -1,0 +1,353 @@
+import {
+  createSignal,
+  createEffect,
+  onCleanup,
+  For,
+  Show,
+  type Component,
+} from "solid-js";
+import "./devtools.css";
+
+interface ConsoleEntry {
+  id: number;
+  timestamp: string;
+  level: string;
+  text: string;
+  url?: string;
+  line?: number;
+}
+
+interface NetworkEntry {
+  id: number;
+  requestId: string;
+  timestamp: string;
+  method: string;
+  url: string;
+  resourceType?: string;
+  status?: number;
+  timing?: { durationMs?: number };
+  error?: string;
+}
+
+interface ErrorEntry {
+  id: number;
+  timestamp: string;
+  type: string;
+  message: string;
+  description?: string;
+}
+
+interface ActivityEntry {
+  id: number;
+  timestamp: string;
+  tool: string;
+  args: string;
+  result: string;
+  durationMs: number;
+  status: "running" | "completed" | "failed";
+}
+
+interface PanelState {
+  console: ConsoleEntry[];
+  network: NetworkEntry[];
+  errors: ErrorEntry[];
+  activity: ActivityEntry[];
+}
+
+type PanelTab = "console" | "network" | "activity";
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
+  } catch {
+    return "";
+  }
+}
+
+function statusClass(status?: number): string {
+  if (status == null) return "pending";
+  if (status >= 200 && status < 300) return "ok";
+  if (status >= 300 && status < 400) return "redirect";
+  return "error";
+}
+
+function shortenUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.pathname + u.search;
+  } catch {
+    return url;
+  }
+}
+
+function shortenSource(url?: string, line?: number): string {
+  if (!url) return "";
+  try {
+    const u = new URL(url);
+    const file = u.pathname.split("/").pop() || u.pathname;
+    return line != null ? `${file}:${line}` : file;
+  } catch {
+    return url;
+  }
+}
+
+const ConsoleView: Component<{ entries: ConsoleEntry[] }> = (props) => {
+  let scrollRef: HTMLDivElement | undefined;
+  let autoScroll = true;
+
+  const onScroll = () => {
+    if (!scrollRef) return;
+    const atBottom =
+      scrollRef.scrollHeight - scrollRef.scrollTop - scrollRef.clientHeight < 30;
+    autoScroll = atBottom;
+  };
+
+  createEffect(() => {
+    // Re-run when entries change
+    props.entries.length;
+    if (autoScroll && scrollRef) {
+      requestAnimationFrame(() => {
+        scrollRef!.scrollTop = scrollRef!.scrollHeight;
+      });
+    }
+  });
+
+  return (
+    <Show
+      when={props.entries.length > 0}
+      fallback={
+        <div class="devtools-empty">
+          Waiting for console output... Console monitoring activates when an
+          agent uses devtools.
+        </div>
+      }
+    >
+      <div class="devtools-console" ref={scrollRef} onScroll={onScroll}>
+        <For each={props.entries}>
+          {(entry) => (
+            <div class={`console-entry level-${entry.level}`}>
+              <span class={`console-level ${entry.level}`}>{entry.level}</span>
+              <span class="console-time">{formatTime(entry.timestamp)}</span>
+              <span class="console-text">{entry.text}</span>
+              <span class="console-source">
+                {shortenSource(entry.url, entry.line)}
+              </span>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+};
+
+const NetworkView: Component<{ entries: NetworkEntry[] }> = (props) => {
+  let scrollRef: HTMLDivElement | undefined;
+  let autoScroll = true;
+
+  const onScroll = () => {
+    if (!scrollRef) return;
+    const atBottom =
+      scrollRef.scrollHeight - scrollRef.scrollTop - scrollRef.clientHeight < 30;
+    autoScroll = atBottom;
+  };
+
+  createEffect(() => {
+    props.entries.length;
+    if (autoScroll && scrollRef) {
+      requestAnimationFrame(() => {
+        scrollRef!.scrollTop = scrollRef!.scrollHeight;
+      });
+    }
+  });
+
+  return (
+    <Show
+      when={props.entries.length > 0}
+      fallback={
+        <div class="devtools-empty">
+          Waiting for network requests... Network monitoring activates when an
+          agent uses devtools.
+        </div>
+      }
+    >
+      <div class="devtools-network" ref={scrollRef} onScroll={onScroll}>
+        <div class="network-header">
+          <span>Method</span>
+          <span>URL</span>
+          <span>Status</span>
+          <span>Type</span>
+          <span>Time</span>
+        </div>
+        <For each={props.entries}>
+          {(entry) => (
+            <div
+              class={`network-entry ${entry.error || (entry.status && entry.status >= 400) ? "error" : ""}`}
+            >
+              <span class="network-method">{entry.method}</span>
+              <span class="network-url" title={entry.url}>
+                {shortenUrl(entry.url)}
+              </span>
+              <span class={`network-status ${statusClass(entry.status)}`}>
+                {entry.error
+                  ? "ERR"
+                  : entry.status != null
+                    ? entry.status
+                    : "..."}
+              </span>
+              <span class="network-type">
+                {entry.resourceType || "—"}
+              </span>
+              <span class="network-duration">
+                {entry.timing?.durationMs != null
+                  ? `${entry.timing.durationMs}ms`
+                  : "—"}
+              </span>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+};
+
+const ActivityView: Component<{ entries: ActivityEntry[] }> = (props) => {
+  let scrollRef: HTMLDivElement | undefined;
+  let autoScroll = true;
+
+  const onScroll = () => {
+    if (!scrollRef) return;
+    const atBottom =
+      scrollRef.scrollHeight - scrollRef.scrollTop - scrollRef.clientHeight < 30;
+    autoScroll = atBottom;
+  };
+
+  createEffect(() => {
+    props.entries.length;
+    if (autoScroll && scrollRef) {
+      requestAnimationFrame(() => {
+        scrollRef!.scrollTop = scrollRef!.scrollHeight;
+      });
+    }
+  });
+
+  return (
+    <Show
+      when={props.entries.length > 0}
+      fallback={
+        <div class="devtools-empty">
+          Waiting for agent devtools activity...
+        </div>
+      }
+    >
+      <div class="devtools-activity" ref={scrollRef} onScroll={onScroll}>
+        <For each={props.entries}>
+          {(entry) => (
+            <div class="activity-entry">
+              <span class="activity-time">
+                {formatTime(entry.timestamp)}
+              </span>
+              <span class="activity-tool">
+                {entry.tool.replace("devtools_", "")}
+              </span>
+              <span class="activity-args" title={entry.args}>
+                {entry.args}
+              </span>
+              <span class={`activity-status ${entry.status}`}>
+                {entry.status === "running"
+                  ? "running..."
+                  : entry.status}
+              </span>
+              <span class="activity-duration">
+                {entry.durationMs > 0 ? `${entry.durationMs}ms` : "—"}
+              </span>
+            </div>
+          )}
+        </For>
+      </div>
+    </Show>
+  );
+};
+
+const DevToolsPanel: Component = () => {
+  const [activeTab, setActiveTab] = createSignal<PanelTab>("console");
+  const [state, setState] = createSignal<PanelState>({
+    console: [],
+    network: [],
+    errors: [],
+    activity: [],
+  });
+
+  createEffect(() => {
+    const cleanup = window.vessel.devtoolsPanel.onStateUpdate(
+      (newState: PanelState) => {
+        setState(newState);
+      },
+    );
+    onCleanup(cleanup);
+  });
+
+  const errorCount = () => state().errors.length;
+  const networkCount = () => state().network.length;
+  const activityRunning = () =>
+    state().activity.filter((a) => a.status === "running").length;
+
+  const close = () => {
+    window.vessel.devtoolsPanel.toggle();
+  };
+
+  return (
+    <div class="devtools-panel">
+      <div class="devtools-tabs">
+        <button
+          class={`devtools-tab ${activeTab() === "console" ? "active" : ""}`}
+          onClick={() => setActiveTab("console")}
+        >
+          Console
+          <Show when={errorCount() > 0}>
+            <span class="devtools-tab-badge error">{errorCount()}</span>
+          </Show>
+        </button>
+        <button
+          class={`devtools-tab ${activeTab() === "network" ? "active" : ""}`}
+          onClick={() => setActiveTab("network")}
+        >
+          Network
+          <Show when={networkCount() > 0}>
+            <span class="devtools-tab-badge count">{networkCount()}</span>
+          </Show>
+        </button>
+        <button
+          class={`devtools-tab ${activeTab() === "activity" ? "active" : ""}`}
+          onClick={() => setActiveTab("activity")}
+        >
+          Activity
+          <Show when={activityRunning() > 0}>
+            <span class="devtools-tab-badge count">{activityRunning()}</span>
+          </Show>
+        </button>
+        <div class="devtools-tab-spacer" />
+        <button class="devtools-close-btn" onClick={close} title="Close DevTools">
+          ×
+        </button>
+      </div>
+      <div class="devtools-content">
+        <Show when={activeTab() === "console"}>
+          <ConsoleView entries={state().console} />
+        </Show>
+        <Show when={activeTab() === "network"}>
+          <NetworkView entries={state().network} />
+        </Show>
+        <Show when={activeTab() === "activity"}>
+          <ActivityView entries={state().activity} />
+        </Show>
+      </div>
+    </div>
+  );
+};
+
+export default DevToolsPanel;

--- a/src/renderer/src/components/devtools/devtools.css
+++ b/src/renderer/src/components/devtools/devtools.css
@@ -1,0 +1,356 @@
+.devtools-panel {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  overflow: hidden;
+  border-top: 1px solid var(--border-visible);
+}
+
+/* Tab bar */
+.devtools-tabs {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-subtle);
+  padding: 0 8px;
+  height: 32px;
+  flex-shrink: 0;
+  user-select: none;
+}
+
+.devtools-tab {
+  padding: 6px 14px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  border: none;
+  background: none;
+  border-bottom: 2px solid transparent;
+  transition: color var(--duration-fast) var(--ease-in-out),
+              border-color var(--duration-fast) var(--ease-in-out);
+  font-family: var(--font-ui);
+  letter-spacing: 0.02em;
+}
+
+.devtools-tab:hover {
+  color: var(--text-secondary);
+}
+
+.devtools-tab.active {
+  color: var(--accent-primary);
+  border-bottom-color: var(--accent-primary);
+}
+
+.devtools-tab-spacer {
+  flex: 1;
+}
+
+.devtools-tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  font-size: 10px;
+  font-weight: 600;
+  margin-left: 6px;
+}
+
+.devtools-tab-badge.error {
+  background: rgba(192, 112, 112, 0.2);
+  color: var(--error);
+}
+
+.devtools-tab-badge.count {
+  background: rgba(196, 160, 90, 0.15);
+  color: var(--accent-primary);
+}
+
+.devtools-close-btn {
+  padding: 4px 8px;
+  font-size: 14px;
+  color: var(--text-muted);
+  cursor: pointer;
+  border: none;
+  background: none;
+  border-radius: var(--radius-sm);
+  line-height: 1;
+  font-family: var(--font-ui);
+}
+
+.devtools-close-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+/* Content area */
+.devtools-content {
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.devtools-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+/* Console view */
+.devtools-console {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.console-entry {
+  display: flex;
+  padding: 2px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.console-entry:hover {
+  background: var(--bg-secondary);
+}
+
+.console-entry.level-error {
+  background: rgba(192, 112, 112, 0.06);
+  border-left: 2px solid var(--error);
+}
+
+.console-entry.level-warning {
+  background: rgba(196, 160, 90, 0.06);
+  border-left: 2px solid var(--accent-primary);
+}
+
+.console-entry.level-info {
+  border-left: 2px solid var(--accent-secondary);
+}
+
+.console-level {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  width: 40px;
+  flex-shrink: 0;
+  padding-top: 1px;
+}
+
+.console-level.log { color: var(--text-secondary); }
+.console-level.info { color: var(--accent-secondary); }
+.console-level.warning { color: var(--accent-primary); }
+.console-level.error { color: var(--error); }
+.console-level.debug { color: var(--text-muted); }
+
+.console-text {
+  flex: 1;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text-primary);
+}
+
+.console-source {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.console-time {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  width: 60px;
+}
+
+/* Network view */
+.devtools-network {
+  flex: 1;
+  overflow-y: auto;
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.network-header {
+  display: grid;
+  grid-template-columns: 60px 1fr 80px 60px 80px;
+  gap: 8px;
+  padding: 4px 12px;
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-visible);
+  font-weight: 600;
+  font-size: 10px;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.network-entry {
+  display: grid;
+  grid-template-columns: 60px 1fr 80px 60px 80px;
+  gap: 8px;
+  padding: 3px 12px;
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: center;
+}
+
+.network-entry:hover {
+  background: var(--bg-secondary);
+}
+
+.network-entry.error {
+  background: rgba(192, 112, 112, 0.06);
+}
+
+.network-method {
+  font-weight: 600;
+  color: var(--accent-warm);
+  font-size: 10px;
+}
+
+.network-url {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-primary);
+}
+
+.network-status {
+  font-weight: 500;
+}
+
+.network-status.ok { color: var(--accent-secondary); }
+.network-status.redirect { color: var(--accent-primary); }
+.network-status.error { color: var(--error); }
+.network-status.pending { color: var(--text-muted); }
+
+.network-type {
+  color: var(--text-muted);
+  font-size: 10px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.network-duration {
+  color: var(--text-secondary);
+  font-size: 10px;
+  text-align: right;
+}
+
+/* Activity view */
+.devtools-activity {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+  font-size: 11px;
+}
+
+.activity-entry {
+  display: flex;
+  padding: 4px 12px;
+  gap: 10px;
+  border-bottom: 1px solid var(--border-subtle);
+  align-items: flex-start;
+}
+
+.activity-entry:hover {
+  background: var(--bg-secondary);
+}
+
+.activity-tool {
+  font-family: var(--font-mono);
+  font-weight: 600;
+  color: var(--accent-primary);
+  font-size: 11px;
+  flex-shrink: 0;
+  min-width: 180px;
+}
+
+.activity-args {
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+  font-size: 10px;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.activity-status {
+  font-size: 10px;
+  font-weight: 600;
+  flex-shrink: 0;
+  width: 70px;
+  text-align: right;
+}
+
+.activity-status.running { color: var(--accent-primary); }
+.activity-status.completed { color: var(--accent-secondary); }
+.activity-status.failed { color: var(--error); }
+
+.activity-duration {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  width: 50px;
+  text-align: right;
+}
+
+.activity-time {
+  font-size: 10px;
+  color: var(--text-muted);
+  flex-shrink: 0;
+  width: 60px;
+}
+
+/* Scrollbar styling */
+.devtools-console::-webkit-scrollbar,
+.devtools-network::-webkit-scrollbar,
+.devtools-activity::-webkit-scrollbar {
+  width: 6px;
+}
+
+.devtools-console::-webkit-scrollbar-track,
+.devtools-network::-webkit-scrollbar-track,
+.devtools-activity::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.devtools-console::-webkit-scrollbar-thumb,
+.devtools-network::-webkit-scrollbar-thumb,
+.devtools-activity::-webkit-scrollbar-thumb {
+  background: var(--bg-elevated);
+  border-radius: 3px;
+}
+
+.devtools-console::-webkit-scrollbar-thumb:hover,
+.devtools-network::-webkit-scrollbar-thumb:hover,
+.devtools-activity::-webkit-scrollbar-thumb:hover {
+  background: var(--border-visible);
+}

--- a/src/renderer/src/components/devtools/devtools.css
+++ b/src/renderer/src/components/devtools/devtools.css
@@ -329,6 +329,158 @@
   width: 60px;
 }
 
+/* Export dropdown */
+.devtools-export-wrap {
+  position: relative;
+}
+
+.devtools-close-btn.active {
+  color: var(--accent-primary);
+  background: rgba(196, 160, 90, 0.12);
+}
+
+.devtools-export-dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  width: 220px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-visible);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  padding: 10px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.export-section {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+
+.export-section-label {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+  margin-bottom: 2px;
+}
+
+.export-checkbox {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 2px 0;
+}
+
+.export-checkbox:hover {
+  color: var(--text-primary);
+}
+
+.export-checkbox input[type="checkbox"] {
+  accent-color: var(--accent-primary);
+  width: 13px;
+  height: 13px;
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+.export-date-btns {
+  display: flex;
+  gap: 4px;
+}
+
+.export-date-btn {
+  flex: 1;
+  padding: 4px 8px;
+  font-size: 11px;
+  font-family: var(--font-ui);
+  color: var(--text-secondary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--duration-fast), color var(--duration-fast);
+}
+
+.export-date-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+}
+
+.export-date-btn.active {
+  color: var(--accent-primary);
+  background: rgba(196, 160, 90, 0.12);
+  border-color: rgba(196, 160, 90, 0.3);
+}
+
+.export-date-inputs {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-top: 2px;
+}
+
+.export-date-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.export-date-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  width: 28px;
+  flex-shrink: 0;
+}
+
+.export-date-input {
+  flex: 1;
+  padding: 3px 6px;
+  font-size: 11px;
+  font-family: var(--font-ui);
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  outline: none;
+  color-scheme: dark;
+}
+
+.export-date-input:focus {
+  border-color: rgba(196, 160, 90, 0.4);
+}
+
+.export-submit {
+  width: 100%;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  font-family: var(--font-ui);
+  color: var(--bg-primary);
+  background: var(--accent-primary);
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: opacity var(--duration-fast);
+}
+
+.export-submit:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.export-submit:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
 /* Scrollbar styling */
 .devtools-console::-webkit-scrollbar,
 .devtools-network::-webkit-scrollbar,

--- a/src/renderer/src/components/shared/Settings.tsx
+++ b/src/renderer/src/components/shared/Settings.tsx
@@ -6,6 +6,7 @@ import {
   onMount,
   type Component,
 } from "solid-js";
+
 import { useUI } from "../../stores/ui";
 import type {
   AgentTranscriptDisplayMode,
@@ -18,7 +19,7 @@ const CHAT_PROVIDERS: Array<{ id: ProviderId; name: string; requiresKey: boolean
   { id: "anthropic", name: "Anthropic", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-ant-...", defaultModel: "claude-sonnet-4-20250514", models: ["claude-sonnet-4-20250514", "claude-opus-4-20250514", "claude-haiku-4-20250506"] },
   { id: "openai", name: "OpenAI", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-...", defaultModel: "gpt-4o", models: ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "o3-mini"] },
   { id: "openrouter", name: "OpenRouter", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-or-...", defaultModel: "anthropic/claude-sonnet-4", models: ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.5-pro"] },
-  { id: "ollama", name: "Ollama (Local)", requiresKey: false, needsBaseUrl: false, keyPlaceholder: "", defaultModel: "llama3.1", models: ["llama3.1", "llama3.2", "mistral", "gemma2", "qwen2.5"] },
+  { id: "ollama", name: "Ollama (Local)", requiresKey: false, needsBaseUrl: false, keyPlaceholder: "", defaultModel: "", models: [] },
   { id: "mistral", name: "Mistral AI", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-...", defaultModel: "mistral-large-latest", models: ["mistral-large-latest", "mistral-small-latest", "codestral-latest"] },
   { id: "xai", name: "xAI (Grok)", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "xai-...", defaultModel: "grok-3", models: ["grok-3", "grok-3-mini"] },
   { id: "google", name: "Google Gemini", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "AI...", defaultModel: "gemini-2.5-pro", models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"] },
@@ -48,6 +49,57 @@ const Settings: Component = () => {
   const [chatBaseUrl, setChatBaseUrl] = createSignal("");
 
   const chatProviderMeta = () => CHAT_PROVIDERS.find((p) => p.id === chatProviderId()) ?? CHAT_PROVIDERS[0];
+
+  const [providerModels, setProviderModels] = createSignal<string[]>([]);
+  const [modelFetchState, setModelFetchState] = createSignal<"idle" | "loading" | "error">("idle");
+
+  const doFetchModels = () => {
+    const meta = chatProviderMeta();
+    // Need a key for providers that require one
+    if (meta.requiresKey && !chatApiKey().trim()) {
+      setProviderModels([]);
+      setModelFetchState("idle");
+      return;
+    }
+    setModelFetchState("loading");
+    window.vessel.ai.fetchModels({
+      id: chatProviderId(),
+      apiKey: chatApiKey().trim(),
+      model: "",
+      baseUrl: chatBaseUrl().trim() || meta.defaultBaseUrl || undefined,
+    }).then(({ ok, models }) => {
+      if (ok) {
+        setProviderModels(models.sort());
+        if (models.length > 0 && !chatModel()) setChatModel(models[0]);
+        setModelFetchState("idle");
+      } else {
+        setProviderModels([]);
+        setModelFetchState("error");
+      }
+    }).catch(() => {
+      setProviderModels([]);
+      setModelFetchState("error");
+    });
+  };
+
+  // Auto-fetch when provider switches or when api key is filled in
+  createEffect(() => {
+    if (!chatEnabled()) return;
+    const meta = chatProviderMeta();
+    chatProviderId(); // track
+    if (!meta.requiresKey) {
+      doFetchModels();
+    }
+  });
+
+  // When key is provided for a keyed provider, fetch on provider switch
+  createEffect(() => {
+    if (!chatEnabled()) return;
+    const meta = chatProviderMeta();
+    if (meta.requiresKey && chatApiKey().trim()) {
+      doFetchModels();
+    }
+  });
 
   const loadState = async () => {
     const settings = await window.vessel.settings.get();
@@ -331,6 +383,8 @@ const Settings: Component = () => {
                   setChatModel("");
                   setChatBaseUrl("");
                   setChatApiKey("");
+                  setProviderModels([]);
+                  setModelFetchState("idle");
                 }}
               >
                 <For each={CHAT_PROVIDERS}>
@@ -356,20 +410,54 @@ const Settings: Component = () => {
 
             <div class="settings-field">
               <label class="settings-label" for="chat-model">Model</label>
-              <input
-                id="chat-model"
-                class="settings-input"
-                list="chat-model-list"
-                value={chatModel()}
-                onInput={(e) => setChatModel(e.currentTarget.value)}
-                placeholder={chatProviderMeta().defaultModel || "model name"}
-                spellcheck={false}
-              />
-              <datalist id="chat-model-list">
-                <For each={chatProviderMeta().models}>
-                  {(m) => <option value={m} />}
-                </For>
-              </datalist>
+              <div style="display:flex;gap:6px;align-items:center">
+                <Show
+                  when={providerModels().length > 0}
+                  fallback={
+                    <input
+                      id="chat-model"
+                      class="settings-input"
+                      style="flex:1"
+                      value={chatModel()}
+                      onInput={(e) => setChatModel(e.currentTarget.value)}
+                      placeholder={
+                        modelFetchState() === "loading"
+                          ? "Fetching models…"
+                          : chatProviderMeta().requiresKey && !chatApiKey().trim()
+                            ? "Enter API key to load models"
+                            : chatProviderMeta().defaultModel || "model name"
+                      }
+                      spellcheck={false}
+                    />
+                  }
+                >
+                  <select
+                    id="chat-model"
+                    class="settings-input settings-select"
+                    style="flex:1"
+                    value={chatModel()}
+                    onChange={(e) => setChatModel(e.currentTarget.value)}
+                  >
+                    <For each={providerModels()}>
+                      {(m) => <option value={m}>{m}</option>}
+                    </For>
+                  </select>
+                </Show>
+                <button
+                  type="button"
+                  class="settings-refresh-btn"
+                  title="Refresh model list"
+                  disabled={modelFetchState() === "loading"}
+                  onClick={doFetchModels}
+                >
+                  ↺
+                </button>
+              </div>
+              <Show when={modelFetchState() === "error"}>
+                <p class="settings-hint" style="color:var(--error)">
+                  Could not fetch models — check your API key and connection.
+                </p>
+              </Show>
             </div>
 
             <Show when={chatProviderMeta().needsBaseUrl || chatProviderId() === "custom"}>
@@ -616,6 +704,26 @@ const Settings: Component = () => {
           height: 1px;
           background: var(--border-subtle);
           margin: 22px 0 18px;
+        }
+        .settings-refresh-btn {
+          height: 34px;
+          width: 34px;
+          flex-shrink: 0;
+          background: var(--bg-tertiary);
+          border: 1px solid var(--border-subtle);
+          border-radius: var(--radius-md);
+          color: var(--text-secondary);
+          font-size: 16px;
+          cursor: pointer;
+          transition: background var(--duration-fast), color var(--duration-fast);
+        }
+        .settings-refresh-btn:hover:not(:disabled) {
+          background: var(--border-visible);
+          color: var(--text-primary);
+        }
+        .settings-refresh-btn:disabled {
+          opacity: 0.4;
+          cursor: default;
         }
       `}</style>
     </Show>

--- a/src/renderer/src/components/shared/Settings.tsx
+++ b/src/renderer/src/components/shared/Settings.tsx
@@ -1,6 +1,7 @@
 import {
   createEffect,
   createSignal,
+  For,
   Show,
   onMount,
   type Component,
@@ -8,8 +9,21 @@ import {
 import { useUI } from "../../stores/ui";
 import type {
   AgentTranscriptDisplayMode,
+  ProviderId,
+  ProviderConfig,
   RuntimeHealthState,
 } from "../../../shared/types";
+
+const CHAT_PROVIDERS: Array<{ id: ProviderId; name: string; requiresKey: boolean; needsBaseUrl: boolean; defaultBaseUrl?: string; keyPlaceholder: string; defaultModel: string; models: string[] }> = [
+  { id: "anthropic", name: "Anthropic", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-ant-...", defaultModel: "claude-sonnet-4-20250514", models: ["claude-sonnet-4-20250514", "claude-opus-4-20250514", "claude-haiku-4-20250506"] },
+  { id: "openai", name: "OpenAI", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-...", defaultModel: "gpt-4o", models: ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini", "o3-mini"] },
+  { id: "openrouter", name: "OpenRouter", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-or-...", defaultModel: "anthropic/claude-sonnet-4", models: ["anthropic/claude-sonnet-4", "openai/gpt-4o", "google/gemini-2.5-pro"] },
+  { id: "ollama", name: "Ollama (Local)", requiresKey: false, needsBaseUrl: false, keyPlaceholder: "", defaultModel: "llama3.1", models: ["llama3.1", "llama3.2", "mistral", "gemma2", "qwen2.5"] },
+  { id: "mistral", name: "Mistral AI", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "sk-...", defaultModel: "mistral-large-latest", models: ["mistral-large-latest", "mistral-small-latest", "codestral-latest"] },
+  { id: "xai", name: "xAI (Grok)", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "xai-...", defaultModel: "grok-3", models: ["grok-3", "grok-3-mini"] },
+  { id: "google", name: "Google Gemini", requiresKey: true, needsBaseUrl: false, keyPlaceholder: "AI...", defaultModel: "gemini-2.5-pro", models: ["gemini-2.5-pro", "gemini-2.5-flash", "gemini-2.0-flash"] },
+  { id: "custom", name: "Custom (OAI-Compatible)", requiresKey: false, needsBaseUrl: true, defaultBaseUrl: "http://localhost:8080/v1", keyPlaceholder: "", defaultModel: "", models: [] },
+];
 
 const Settings: Component = () => {
   const { settingsOpen, closeSettings } = useUI();
@@ -26,6 +40,15 @@ const Settings: Component = () => {
     text: string;
   } | null>(null);
 
+  // Chat provider settings
+  const [chatEnabled, setChatEnabled] = createSignal(false);
+  const [chatProviderId, setChatProviderId] = createSignal<ProviderId>("anthropic");
+  const [chatApiKey, setChatApiKey] = createSignal("");
+  const [chatModel, setChatModel] = createSignal("");
+  const [chatBaseUrl, setChatBaseUrl] = createSignal("");
+
+  const chatProviderMeta = () => CHAT_PROVIDERS.find((p) => p.id === chatProviderId()) ?? CHAT_PROVIDERS[0];
+
   const loadState = async () => {
     const settings = await window.vessel.settings.get();
     const runtimeHealth = await window.vessel.settings.getHealth();
@@ -35,6 +58,14 @@ const Settings: Component = () => {
     setMcpPort(String(settings.mcpPort ?? 3100));
     setAgentTranscriptMode(settings.agentTranscriptMode ?? "summary");
     setHealth(runtimeHealth);
+    const cp = settings.chatProvider ?? null;
+    setChatEnabled(cp !== null);
+    if (cp) {
+      setChatProviderId(cp.id);
+      setChatApiKey(cp.apiKey);
+      setChatModel(cp.model);
+      setChatBaseUrl(cp.baseUrl ?? "");
+    }
   };
 
   onMount(() => {
@@ -79,6 +110,15 @@ const Settings: Component = () => {
         "agentTranscriptMode",
         agentTranscriptMode(),
       );
+      const chatConfig: ProviderConfig | null = chatEnabled()
+        ? {
+            id: chatProviderId(),
+            apiKey: chatApiKey().trim(),
+            model: chatModel().trim() || chatProviderMeta().defaultModel,
+            baseUrl: chatBaseUrl().trim() || undefined,
+          }
+        : null;
+      await window.vessel.settings.set("chatProvider", chatConfig);
       await loadState();
       setStatus({
         kind: "success",
@@ -256,6 +296,96 @@ const Settings: Component = () => {
               cleared each time Vessel starts.
             </p>
           </div>
+
+          <div class="settings-section-divider" />
+
+          <div class="settings-field">
+            <label class="settings-toggle">
+              <button
+                type="button"
+                class="toggle-switch"
+                classList={{ on: chatEnabled() }}
+                onClick={() => setChatEnabled(!chatEnabled())}
+                role="switch"
+                aria-checked={chatEnabled()}
+              >
+                <span class="toggle-switch-thumb" />
+              </button>
+              <span>Enable Chat Assistant</span>
+            </label>
+            <p class="settings-hint">
+              Adds a Chat tab to the sidebar for conversing with an AI provider of your choice.
+            </p>
+          </div>
+
+          <Show when={chatEnabled()}>
+            <div class="settings-field">
+              <label class="settings-label" for="chat-provider">Provider</label>
+              <select
+                id="chat-provider"
+                class="settings-input settings-select"
+                value={chatProviderId()}
+                onChange={(e) => {
+                  const id = e.currentTarget.value as ProviderId;
+                  setChatProviderId(id);
+                  setChatModel("");
+                  setChatBaseUrl("");
+                  setChatApiKey("");
+                }}
+              >
+                <For each={CHAT_PROVIDERS}>
+                  {(p) => <option value={p.id}>{p.name}</option>}
+                </For>
+              </select>
+            </div>
+
+            <Show when={chatProviderMeta().requiresKey}>
+              <div class="settings-field">
+                <label class="settings-label" for="chat-api-key">API Key</label>
+                <input
+                  id="chat-api-key"
+                  class="settings-input"
+                  type="password"
+                  value={chatApiKey()}
+                  onInput={(e) => setChatApiKey(e.currentTarget.value)}
+                  placeholder={chatProviderMeta().keyPlaceholder}
+                  spellcheck={false}
+                />
+              </div>
+            </Show>
+
+            <div class="settings-field">
+              <label class="settings-label" for="chat-model">Model</label>
+              <input
+                id="chat-model"
+                class="settings-input"
+                list="chat-model-list"
+                value={chatModel()}
+                onInput={(e) => setChatModel(e.currentTarget.value)}
+                placeholder={chatProviderMeta().defaultModel || "model name"}
+                spellcheck={false}
+              />
+              <datalist id="chat-model-list">
+                <For each={chatProviderMeta().models}>
+                  {(m) => <option value={m} />}
+                </For>
+              </datalist>
+            </div>
+
+            <Show when={chatProviderMeta().needsBaseUrl || chatProviderId() === "custom"}>
+              <div class="settings-field">
+                <label class="settings-label" for="chat-base-url">Base URL</label>
+                <input
+                  id="chat-base-url"
+                  class="settings-input"
+                  value={chatBaseUrl()}
+                  onInput={(e) => setChatBaseUrl(e.currentTarget.value)}
+                  placeholder={chatProviderMeta().defaultBaseUrl ?? "https://..."}
+                  spellcheck={false}
+                />
+              </div>
+            </Show>
+          </Show>
 
           <div class="settings-actions">
             <button class="settings-save" onClick={handleSave}>
@@ -482,6 +612,11 @@ const Settings: Component = () => {
           color: var(--text-secondary);
         }
         .settings-close:hover { background: var(--border-visible); }
+        .settings-section-divider {
+          height: 1px;
+          background: var(--border-subtle);
+          margin: 22px 0 18px;
+        }
       `}</style>
     </Show>
   );

--- a/src/renderer/src/lib/keybindings.ts
+++ b/src/renderer/src/lib/keybindings.ts
@@ -6,6 +6,7 @@ interface KeyBindingHandlers {
   closeTab: () => void;
   openSettings: () => void;
   captureHighlight: () => void;
+  toggleDevTools?: () => void;
 }
 
 export function setupKeybindings(handlers: KeyBindingHandlers): () => void {
@@ -58,6 +59,13 @@ export function setupKeybindings(handlers: KeyBindingHandlers): () => void {
     if (ctrl && e.key === 'h' && !e.shiftKey) {
       e.preventDefault();
       handlers.captureHighlight();
+      return;
+    }
+
+    // F12 — toggle DevTools panel
+    if (e.key === 'F12') {
+      e.preventDefault();
+      handlers.toggleDevTools?.();
       return;
     }
   };

--- a/src/renderer/src/stores/ai.ts
+++ b/src/renderer/src/stores/ai.ts
@@ -56,7 +56,7 @@ export function useAI() {
         const filtered = prev.filter((q) => q !== prompt);
         return [prompt, ...filtered].slice(0, MAX_RECENT_QUERIES);
       });
-      await window.vessel.ai.query(prompt);
+      await window.vessel.ai.query(prompt, messages());
     },
     cancel: () => window.vessel.ai.cancel(),
     clearHistory: () => setMessages([]),

--- a/src/renderer/src/stores/ui.ts
+++ b/src/renderer/src/stores/ui.ts
@@ -9,6 +9,7 @@ const [sidebarWidth, setSidebarWidth] = createSignal(DEFAULT_SIDEBAR_WIDTH);
 const [focusMode, setFocusMode] = createSignal(false);
 const [commandBarOpen, setCommandBarOpen] = createSignal(false);
 const [settingsOpen, setSettingsOpen] = createSignal(false);
+const [devtoolsPanelOpen, setDevtoolsPanelOpen] = createSignal(false);
 
 // Throttled IPC for resize — fire at most once per animation frame
 let resizeRafId: number | null = null;
@@ -29,6 +30,7 @@ export function useUI() {
     focusMode,
     commandBarOpen,
     settingsOpen,
+    devtoolsPanelOpen,
     toggleSidebar: async () => {
       const result = await window.vessel.ui.toggleSidebar();
       setSidebarOpen(result.open);
@@ -61,6 +63,10 @@ export function useUI() {
     toggleFocusMode: async () => {
       const result = await window.vessel.ui.toggleFocusMode();
       setFocusMode(result);
+    },
+    toggleDevTools: async () => {
+      const result = await window.vessel.devtoolsPanel.toggle();
+      setDevtoolsPanelOpen(result.open);
     },
     openCommandBar: () => setCommandBarOpen(true),
     closeCommandBar: () => setCommandBarOpen(false),

--- a/src/renderer/src/styles/theme.css
+++ b/src/renderer/src/styles/theme.css
@@ -25,7 +25,7 @@
   --success: #70a070;
 
   /* Dimensions */
-  --chrome-height: 80px;
+  --chrome-height: 110px;
   --sidebar-width: 340px;
   --tab-height: 36px;
   --address-bar-height: 40px;

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -56,6 +56,10 @@ export const Channels = {
   HIGHLIGHT_CAPTURE_RESULT: "highlights:capture-result",
   HIGHLIGHT_SELECTION: "vessel:highlight-selection",
 
+  // DevTools panel
+  DEVTOOLS_PANEL_TOGGLE: "devtools-panel:toggle",
+  DEVTOOLS_PANEL_STATE: "devtools-panel:state",
+
   // Window controls
   WINDOW_MINIMIZE: "window:minimize",
   WINDOW_MAXIMIZE: "window:maximize",

--- a/src/shared/channels.ts
+++ b/src/shared/channels.ts
@@ -15,6 +15,7 @@ export const Channels = {
   AI_STREAM_CHUNK: "ai:stream-chunk",
   AI_STREAM_END: "ai:stream-end",
   AI_CANCEL: "ai:cancel",
+  AI_FETCH_MODELS: "ai:fetch-models",
   AGENT_RUNTIME_GET: "agent-runtime:get",
   AGENT_RUNTIME_UPDATE: "agent-runtime:update",
   AGENT_PAUSE: "agent:pause",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -344,6 +344,7 @@ export interface VesselSettings {
   obsidianVaultPath: string;
   approvalMode: ApprovalMode;
   agentTranscriptMode: AgentTranscriptDisplayMode;
+  chatProvider: ProviderConfig | null;
 }
 
 export type RuntimeHealthSeverity = "warning" | "error";

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -289,6 +289,8 @@ export interface UIState {
   sidebarWidth: number;
   focusMode: boolean;
   settingsOpen: boolean;
+  devtoolsPanelOpen: boolean;
+  devtoolsPanelHeight: number;
 }
 
 // --- Provider types ---


### PR DESCRIPTION
## Summary
- Configure `package.json` for npm distribution: scoped package name (`@quanta-intellect/vessel-browser`), `bin` entry point for `vessel-browser` CLI, `files` whitelist, `publishConfig` for public access
- Add CLI launcher script (`bin/vessel-browser.js`) so users can `npm install -g @quanta-intellect/vessel-browser && vessel-browser`
- Extend release workflow to publish to npm registry alongside GitHub Releases (uses `NPM_TOKEN` secret)
- Fix sidebar tab bar overflow that clipped the chat tab at narrow sidebar widths (reduced padding, added flex-shrink)

## Test plan
- [ ] Verify `npm run build` completes cleanly
- [ ] Verify `npm pack --dry-run` includes only expected files (~223 kB)
- [ ] Verify `npm run dev` launches correctly with sidebar chat tab fully visible
- [ ] Verify release workflow triggers npm publish on `v*` tag push
- [ ] Confirm `NPM_TOKEN` secret is configured in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)