### PR TITLE
fix: persist MCP auth token to disk for external clients

### DIFF
--- a/src/main/mcp/server.ts
+++ b/src/main/mcp/server.ts
@@ -68,6 +68,47 @@ import { trackVaultAction } from "../telemetry/posthog";
 let httpServer: http.Server | null = null;
 let mcpAuthToken: string | null = null;
 
+// Well-known path where external MCP clients (e.g. Hermes) can read the
+// current auth token and endpoint.  Written on successful start, cleared on
+// stop.  Lives inside the Electron userData directory so it survives restarts
+// but is always fresh (token is regenerated each launch).
+const MCP_AUTH_FILENAME = "mcp-auth.json";
+
+function getMcpAuthFilePath(): string {
+  // Electron stores userData at ~/.config/<appName> on Linux.  We resolve the
+  // same directory via the XDG convention without importing `app` (which may
+  // not be available during tests).
+  const configDir =
+    process.env.VESSEL_CONFIG_DIR ||
+    path.join(
+      process.env.XDG_CONFIG_HOME || path.join(os.homedir(), ".config"),
+      "vessel",
+    );
+  return path.join(configDir, MCP_AUTH_FILENAME);
+}
+
+function writeMcpAuthFile(endpoint: string, token: string): void {
+  try {
+    const filePath = getMcpAuthFilePath();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ endpoint, token, pid: process.pid }, null, 2) + "\n",
+      { mode: 0o600 },
+    );
+  } catch (err) {
+    console.warn("[Vessel MCP] Failed to write auth file:", err);
+  }
+}
+
+function clearMcpAuthFile(): void {
+  try {
+    fs.unlinkSync(getMcpAuthFilePath());
+  } catch {
+    // File may not exist — that's fine.
+  }
+}
+
 /** Returns the current MCP auth token (generated fresh on each server start). */
 export function getMcpAuthToken(): string | null {
   return mcpAuthToken;
@@ -5818,6 +5859,7 @@ export function startMcpServer(
           ? `Port ${port} is already in use. MCP server not started.`
           : error.message;
       console.error("[Vessel MCP] Server error:", error);
+      clearMcpAuthFile();
       setMcpHealth({
         configuredPort: port,
         activePort: null,
@@ -5852,6 +5894,9 @@ export function startMcpServer(
         message: `MCP server listening on ${endpoint}.`,
       });
       console.log(`[Vessel MCP] Server listening on ${endpoint} (auth enabled)`);
+      if (mcpAuthToken) {
+        writeMcpAuthFile(endpoint, mcpAuthToken);
+      }
       finish({
         ok: true,
         configuredPort: port,
@@ -5879,6 +5924,7 @@ export function stopMcpServer(): Promise<void> {
     const server = httpServer;
     httpServer = null;
     mcpAuthToken = null;
+    clearMcpAuthFile();
     server.close(() => {
       setMcpHealth({
         activePort: null,


### PR DESCRIPTION
## Summary

- Vessel's MCP server generates a random bearer token on each start but only stores it in memory — external MCP clients (Hermes, Claude Code, etc.) have no way to read it and get 401 Unauthorized on every request
- Writes `~/.config/vessel/mcp-auth.json` (endpoint, token, PID) on successful start with `0600` permissions
- Clears the file on server stop or error so stale tokens don't linger

## Context

The Hermes agent config (`~/.hermes/config.yaml`) has the Vessel MCP server registered at `http://127.0.0.1:3100/mcp` but with no auth header. Every call returns:

```json
{"error":"Unauthorized — missing or invalid bearer token"}
```

With this change, clients can read the token at connect time:

```bash
cat ~/.config/vessel/mcp-auth.json
# {"endpoint":"http://127.0.0.1:3100/mcp","token":"<hex>","pid":12345}
```

And configure their MCP client accordingly (e.g. `Authorization: Bearer <token>`).

## Test plan

- [ ] Start Vessel — verify `~/.config/vessel/mcp-auth.json` is created with correct endpoint and a 64-char hex token
- [ ] Verify file permissions are `0600`
- [ ] Use the token in a curl request: `curl -H "Authorization: Bearer <token>" http://127.0.0.1:3100/mcp` — should not return 401
- [ ] Stop Vessel — verify `mcp-auth.json` is deleted
- [ ] Kill Vessel (simulate crash) — on next start, file is overwritten with fresh token
- [ ] Verify `VESSEL_CONFIG_DIR` env override works for non-standard config paths